### PR TITLE
example import order

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -40,8 +40,8 @@ rm -fR ${BUILDDIR}
 mkdir -p ${BUILDDIR}
 
 cd /var/www/miq/vmdb
-bin/rake rhconsulting:service_catalogs:export[${BUILDDIR}/service_catalogs]
 bin/rake rhconsulting:dialogs:export[${BUILDDIR}/dialogs]
+bin/rake rhconsulting:service_catalogs:export[${BUILDDIR}/service_catalogs]
 bin/rake rhconsulting:roles:export[${BUILDDIR}/roles/roles.yml]
 bin/rake rhconsulting:tags:export[${BUILDDIR}/tags/tags.yml]
 bin/rake rhconsulting:buttons:export[${BUILDDIR}/buttons/buttons.yml]

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ rm -fR ${BUILDDIR}
 mkdir -p ${BUILDDIR}
 
 cd /var/www/miq/vmdb
-bin/rake rhconsulting:service_catalogs:export[${BUILDDIR}/service_catalogs]
 bin/rake rhconsulting:dialogs:export[${BUILDDIR}/dialogs]
+bin/rake rhconsulting:service_catalogs:export[${BUILDDIR}/service_catalogs]
 bin/rake rhconsulting:roles:export[${BUILDDIR}/roles/roles.yml]
 bin/rake rhconsulting:tags:export[${BUILDDIR}/tags/tags.yml]
 bin/rake rhconsulting:buttons:export[${BUILDDIR}/buttons/buttons.yml]


### PR DESCRIPTION
Dialogs should be imported before Service Catalogs in case they are being used by the Service Catalogs.