### PR TITLE
Allow identical button names between types.

### DIFF
--- a/rhconsulting_buttons.rake
+++ b/rhconsulting_buttons.rake
@@ -89,7 +89,11 @@ class ButtonsImportExport
       resource_actions = cb['resource_actions']
       #puts cb['resource_actions'].inspect
       cb.delete('resource_actions')
-      custom_button = CustomButton.in_region(MiqRegion.my_region_number).find_by_name(cb['name'])
+      # The same name can be used in different Object Types so we need to make
+      # sure to check for that.
+      custom_button = CustomButton.in_region(MiqRegion.my_region_number).
+                        find_by_name_and_applies_to_class(cb['name'],
+                                                          cb['applies_to_class'])
       #      custom_button = cb.custom_buttons.find { |x| x.name == cb['name'] }
       custom_button = CustomButton.new(:applies_to_id => "#{parent['id']}") unless custom_button
       #puts "CustomButton search: #{custom_button.inspect}"


### PR DESCRIPTION
In the original code you could not import a file containing two buttons with the same name, but assigned to different object types which is allowed by the Web UI. The export correctly creates the file, so a round trip export -> import does not work.

Example:
InspectMe on Provider (ExtManagementSystem)
InspectMe on Vm

This fix is to find the button by name and object type to allow the import.