### PR TITLE
fix exporting to a file that does not exist

### DIFF
--- a/rhconsulting_buttons.rake
+++ b/rhconsulting_buttons.rake
@@ -15,6 +15,13 @@ class ButtonsImportExport
 
   def export(filename)
     raise "Must supply filename or directory" if filename.blank?
+    begin
+      file_type = File.ftype(filename)
+    rescue
+      # If we get an error back assume it is a filename that does not exist
+      file_type = 'file'
+    end
+
     custom_buttons_sets_hash = export_custom_button_sets(CustomButtonSet.in_region(MiqRegion.my_region_number).order(:id).all)
     custom_button_find = CustomButton.in_region(MiqRegion.my_region_number).order(:id).all
     bf_array = []
@@ -31,9 +38,9 @@ class ButtonsImportExport
 #puts custom_buttons_hash.inspect
 #File.write(filename, {:custom_buttons_sets => custom_buttons_sets_hash, :custom_buttons => custom_buttons_hash}.to_yaml)
 #puts "Filename: #{filename}"
-    if File.file?(filename)
+    if file_type == 'file'
       File.write(filename, {:custom_buttons_sets => custom_buttons_sets_hash}.to_yaml)
-    elsif File.directory?(filename)
+    elsif file_type == 'directory'
       custom_buttons_sets_hash.each do |cbs|
         fname = "#{filename}/#{cbs["name"].gsub("|", "_")}.yaml"
         File.write(fname, {:custom_buttons_sets => [cbs]}.to_yaml)


### PR DESCRIPTION
The original code to export to individual files failed if a filename was specified that did not exist.