### PR TITLE
Added a new export-miqdomain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.3
+VERSION := 0.4
 RELEASE := 2
 
 .PHONY: clean rpm install clean-install
@@ -15,6 +15,7 @@ rm-installed-files:
 	rm -f /var/www/miq/vmdb/lib/tasks/rhconsulting_policies.rake
 	rm -f /usr/bin/miqexport
 	rm -f /usr/bin/miqimport
+	rm -f /usr/bin/export-miqdomain
 
 install:
 	install -Dm644 rhconsulting_buttons.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_buttons.rake
@@ -28,6 +29,7 @@ install:
 	install -Dm644 rhconsulting_policies.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_policies.rake
 	install -Dm755 bin/miqexport /usr/bin/miqexport
 	install -Dm755 bin/miqimport /usr/bin/miqimport
+	install -Dm755 bin/export-miqdomain /usr/bin/export-miqdomain
 
 clean-install: rm-installed-files install
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.4
+VERSION := 0.5
 RELEASE := 2
 
 .PHONY: clean rpm install clean-install
@@ -16,6 +16,7 @@ rm-installed-files:
 	rm -f /usr/bin/miqexport
 	rm -f /usr/bin/miqimport
 	rm -f /usr/bin/export-miqdomain
+	rm -f /usr/bin/import-miqdomain
 
 install:
 	install -Dm644 rhconsulting_buttons.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_buttons.rake
@@ -30,6 +31,7 @@ install:
 	install -Dm755 bin/miqexport /usr/bin/miqexport
 	install -Dm755 bin/miqimport /usr/bin/miqimport
 	install -Dm755 bin/export-miqdomain /usr/bin/export-miqdomain
+	install -Dm755 bin/import-miqdomain /usr/bin/import-miqdomain
 
 clean-install: rm-installed-files install
 

--- a/README.adoc
+++ b/README.adoc
@@ -113,7 +113,7 @@ OPTIONS:
   -h    Displays help
 ----
 
-* To do the export manually follow the below steps.
+* To do the export manually, follow the below steps.
 
 ----
 BUILDDIR=/tmp/CFME-build
@@ -134,6 +134,21 @@ bin/rake "rhconsulting:miq_ae_datastore:export[${DOMAIN_EXPORT}, ${BUILDDIR}/miq
 ----
 
 == Import examples using rake
+
+* You can do the import by using the `import-miqdomain` script or manually as well. 
+
+----
+import-miqdomain 
+Usage: ./import-miqdomain -D /absolute/path/to/the/directory
+
+OPTIONS:
+  -D    Path to the directory
+  -h    Displays help
+
+----
+
+* To do the import manually, follow the below steps.
+
 ----
 BUILDDIR=/tmp/CFME-build
 DOMAIN_IMPORT=YourDomainHere

--- a/README.adoc
+++ b/README.adoc
@@ -102,6 +102,19 @@ miqimport dialogs /tmp/dialogs
 ----
 
 == Export examples using rake
+* You can do the export by using the `export-miqdomain` script or manually as well.
+----
+export-domain 
+Usage: ./export-domain -d CloudFormsDomain -D /path/to/the/directory
+
+OPTIONS:
+  -d    CloudForms Domain
+  -D    Path to the directory
+  -h    Displays help
+----
+
+* To do the export manually follow the below steps.
+
 ----
 BUILDDIR=/tmp/CFME-build
 DOMAIN_EXPORT=YourDomainHere
@@ -116,7 +129,7 @@ bin/rake rhconsulting:roles:export[${BUILDDIR}/roles/roles.yml]
 bin/rake rhconsulting:tags:export[${BUILDDIR}/tags/tags.yml]
 bin/rake rhconsulting:buttons:export[${BUILDDIR}/buttons/buttons.yml]
 bin/rake rhconsulting:customization_templates:export[${BUILDDIR}/customization_templates/customization_templates.yml]
-bin/rake rhconsulting:miq_policies:export[${BUILDDIR/policies]
+bin/rake rhconsulting:miq_policies:export[${BUILDDIR}/policies]
 bin/rake "rhconsulting:miq_ae_datastore:export[${DOMAIN_EXPORT}, ${BUILDDIR}/miq_ae_datastore]"
 ----
 

--- a/bin/export-miqdomain
+++ b/bin/export-miqdomain
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# Red Hat Consulting
+# BASH script to export CloudForms domain to a directory
+
+# Version 1.0 - 2016-04-26
+
+usage()
+{
+cat << EOF
+Usage: $0 -d CloudFormsDomain -D /path/to/the/directory
+
+OPTIONS:
+  -d    CloudForms Domain
+  -D    Path to the directory
+  -h    Displays help
+
+EOF
+}
+
+check_root()
+{
+  if [[ ${EUID} != 0 ]]; then
+    echo "Error: Run the $0 as 'root'." >&2
+    exit 1
+  fi
+}
+
+export ()
+{
+  mkdir -p ${BUILDDIR}/{service_catalogs,dialogs,roles,tags,buttons,customization_templates,policies,miq_ae_datastore}
+
+  cd /var/www/miq/vmdb
+  bin/rake rhconsulting:service_dialogs:export[${BUILDDIR}/dialogs]
+  bin/rake rhconsulting:service_catalogs:export[${BUILDDIR}/service_catalogs]
+  bin/rake rhconsulting:roles:export[${BUILDDIR}/roles/roles.yml]
+  bin/rake rhconsulting:tags:export[${BUILDDIR}/tags/tags.yml]
+  bin/rake rhconsulting:buttons:export[${BUILDDIR}/buttons/buttons.yml]
+  bin/rake rhconsulting:customization_templates:export[${BUILDDIR}/customization_templates/customization_templates.yml]
+  bin/rake rhconsulting:miq_policies:export[${BUILDDIR}/policies]
+  bin/rake "rhconsulting:miq_ae_datastore:export[${DOMAIN}, ${BUILDDIR}/miq_ae_datastore]"
+}
+
+
+## Main
+# Read command line arguments
+while getopts "d:,D:,:h" opts; do
+  case $opts in
+    h)
+      usage
+      exit 1
+      ;;
+    d)
+      DOMAIN=${OPTARG}
+      ;;
+    D)
+      BUILDDIR=${OPTARG}
+      ;;
+    \?)
+      echo "Invalid option -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Options -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+    *)
+      ;;
+  esac
+done
+
+if [[ -z ${DOMAIN} ]] || [[ -z ${BUILDDIR} ]]; then
+  usage
+  exit 1
+fi
+
+# Check for the user 'root'
+check_root
+
+# Confirm before proceeding and then run the export.
+echo "The domain is ${DOMAIN}"
+echo "The directory is ${BUILDDIR}"
+read -r -p "Do you want to continue? [Y/n] " response
+response=${response,}
+
+if [[ $response =~ ^(yes|y) ]]; then
+  echo "Starting export, please wait..."
+  # Start the export
+  export
+else
+  echo "You have decided not to continue."
+  echo "Exiting."
+  exit 1
+fi
+

--- a/bin/export-miqdomain
+++ b/bin/export-miqdomain
@@ -28,14 +28,15 @@ check_root()
 
 export ()
 {
-  mkdir -p ${BUILDDIR}/{service_catalogs,dialogs,roles,tags,buttons,customization_templates,policies,miq_ae_datastore}
+  mkdir -p ${BUILDDIR}/{service_catalogs,service_dialogs,roles,tags,buttons,customization_templates,reports,policies,miq_ae_datastore}
 
   cd /var/www/miq/vmdb
-  bin/rake rhconsulting:service_dialogs:export[${BUILDDIR}/dialogs]
+  bin/rake rhconsulting:service_dialogs:export[${BUILDDIR}/service_dialogs]
   bin/rake rhconsulting:service_catalogs:export[${BUILDDIR}/service_catalogs]
   bin/rake rhconsulting:roles:export[${BUILDDIR}/roles/roles.yml]
   bin/rake rhconsulting:tags:export[${BUILDDIR}/tags/tags.yml]
   bin/rake rhconsulting:buttons:export[${BUILDDIR}/buttons/buttons.yml]
+  bin/rake rhconsulting:miq_reports:export[${BUILDDIR}/reports]
   bin/rake rhconsulting:customization_templates:export[${BUILDDIR}/customization_templates/customization_templates.yml]
   bin/rake rhconsulting:miq_policies:export[${BUILDDIR}/policies]
   bin/rake "rhconsulting:miq_ae_datastore:export[${DOMAIN}, ${BUILDDIR}/miq_ae_datastore]"

--- a/bin/import-miqdomain
+++ b/bin/import-miqdomain
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+# Red Hat Consulting
+# BASH script to import CloudForms domain to a directory
+
+# Version 1.0 - 2016-04-27
+
+usage()
+{
+cat << EOF
+Usage: $0 -D /absolute/path/to/the/directory
+
+OPTIONS:
+  -D    Path to the directory
+  -h    Displays help
+
+EOF
+}
+
+absolute_path()
+{
+  if [[ "${DIR:0:1}" != "/" ]]; then
+    echo "Error: The path to the directory needs to be Absolute Path."
+    exit 1
+  fi
+}
+
+
+check_root()
+{
+  if [[ ${EUID} != 0 ]]; then
+    echo "Error: Run the $0 as 'root'." >&2
+    exit 1
+  fi
+}
+
+check_directory()
+{
+  if [[ ! -d ${DIR} ]]; then
+    echo "Error: The directory does not exist." >&2
+    exit 1
+  fi
+}
+
+
+domain_name()
+{
+  DIRECTORY=`find ${DIR}/miq_ae_datastore/ -maxdepth 1 -type d | tail -1`
+  DOMAIN=`basename ${DIRECTORY}`
+  echo "Domain name to be imported is ${DOMAIN}"
+}
+
+import()
+{
+  cd /var/www/miq/vmdb
+  bin/rake rhconsulting:service_dialogs:import[${DIR}/service_dialogs]
+  bin/rake rhconsulting:roles:import[${DIR}/roles/roles.yml]
+  bin/rake rhconsulting:tags:import[${DIR}/tags/tags.yml]
+  bin/rake rhconsulting:buttons:import[${DIR}/buttons/buttons.yml]
+  bin/rake rhconsulting:customization_templates:import[${DIR}/customization_templates/customization_templates.yml]
+  bin/rake rhconsulting:miq_policies:import[${DIR}/policies]
+  bin/rake rhconsulting:service_catalogs:import[${DIR}/service_catalogs]
+  bin/rake rhconsulting:miq_reports:import[${DIR}/reports]
+  bin/rake "rhconsulting:miq_ae_datastore:import[${DOMAIN}, ${DIR}/miq_ae_datastore]"
+  bin/rake rhconsulting:service_catalogs:import[${DIR}/service_catalogs]
+}
+
+
+## Main
+# Read command line arguments
+while getopts "D:,:h" opts; do
+  case $opts in
+    h)
+      usage
+      exit 1
+      ;;
+    D)
+      DIR=${OPTARG}
+      ;;
+    \?)
+      echo "Invalid option -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Options -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+    *)
+      ;;
+  esac
+done
+
+if [[ -z ${DIR} ]]; then
+  usage
+  exit 1
+fi
+
+# Check for the user 'root'
+check_root
+
+# Check for directory
+check_directory
+
+# Check for absolute path
+absolute_path
+
+# Get the domain name
+domain_name
+
+# Confirm before proceeding and then run the import.
+echo "The directory you specified is ${DIR}"
+read -r -p "Do you want to continue? [Y/n] " response
+response=${response,}
+
+if [[ $response =~ ^(yes|y) ]]; then
+  echo "Starting import, please wait..."
+  # Start the import
+  import
+else
+  echo "You have decided not to continue."
+  echo "Exiting."
+  exit 1
+fi
+

--- a/cfme-rhconsulting-scripts.spec
+++ b/cfme-rhconsulting-scripts.spec
@@ -1,5 +1,5 @@
 Name:      cfme-rhconsulting-scripts
-Version:   0.4
+Version:   0.5
 Release:   2
 Summary:   Red Hat Consulting Scripts for CloudForms
 
@@ -25,7 +25,8 @@ cd %{_builddir}/%{name}
 install --backup --mode=0644 -t "%{buildroot}/var/www/miq/vmdb/lib/tasks/$f" *.rake
 install --backup --mode=0755 -t "%{buildroot}/usr/bin" bin/miqexport
 install --backup --mode=0755 -t "%{buildroot}/usr/bin" bin/miqimport
-install --backup --mode-0755 -t "%{buildroot}/usr/bin" bin/export-miqdomain
+install --backup --mode=0755 -t "%{buildroot}/usr/bin" bin/export-miqdomain
+install --backup --mode=0755 -t "%{buildroot}/usr/bin" bin/import-miqdomain
 
 %files
 /var/www/miq/vmdb/lib/tasks/rhconsulting_buttons.rake
@@ -40,10 +41,14 @@ install --backup --mode-0755 -t "%{buildroot}/usr/bin" bin/export-miqdomain
 /usr/bin/miqexport
 /usr/bin/miqimport
 /usr/bin/export-miqdomain
+/usr/bin/import-miqdomain
 
 %post
 
 %changelog
+* Thu Apr 28 2015 Kumar Jadav <kumar.jadav@redhat.com> 0.5
+- Added the import-miqdomain file.
+
 * Tue Apr 26 2015 Kumar Jadav <kumar.jadav@redhat.com> 0.4
 - Added the export-miqdomain file.
 

--- a/cfme-rhconsulting-scripts.spec
+++ b/cfme-rhconsulting-scripts.spec
@@ -1,5 +1,5 @@
 Name:      cfme-rhconsulting-scripts
-Version:   0.3
+Version:   0.4
 Release:   2
 Summary:   Red Hat Consulting Scripts for CloudForms
 
@@ -25,6 +25,7 @@ cd %{_builddir}/%{name}
 install --backup --mode=0644 -t "%{buildroot}/var/www/miq/vmdb/lib/tasks/$f" *.rake
 install --backup --mode=0755 -t "%{buildroot}/usr/bin" bin/miqexport
 install --backup --mode=0755 -t "%{buildroot}/usr/bin" bin/miqimport
+install --backup --mode-0755 -t "%{buildroot}/usr/bin" bin/export-miqdomain
 
 %files
 /var/www/miq/vmdb/lib/tasks/rhconsulting_buttons.rake
@@ -38,10 +39,14 @@ install --backup --mode=0755 -t "%{buildroot}/usr/bin" bin/miqimport
 /var/www/miq/vmdb/lib/tasks/rhconsulting_policies.rake
 /usr/bin/miqexport
 /usr/bin/miqimport
+/usr/bin/export-miqdomain
 
 %post
 
 %changelog
+* Tue Apr 26 2015 Kumar Jadav <kumar.jadav@redhat.com> 0.4
+- Added the export-miqdomain file.
+
 * Mon Dec 21 2015 George Goh <george.goh@redhat.com> 0.3-2
 - Fix wrong test in miqimport for the existence of files.
 


### PR DESCRIPTION
Hi George et al, 

I've created a new export-miqdomain script. This script allows a user to export the miqdatastore into a Directory. In doing so, it greatly reduces the need for doing it manually. 

I've also updated the RPM spec file and, README and the Makefile. 

Cheers, Kumar