### PR TITLE
Widget support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-VERSION := 0.5
-RELEASE := 2
+VERSION := 0.6
+RELEASE := 1
 
 .PHONY: clean rpm install clean-install
 
@@ -12,6 +12,7 @@ rm-installed-files:
 	rm -f /var/www/miq/vmdb/lib/tasks/rhconsulting_service_catalogs.rake
 	rm -f /var/www/miq/vmdb/lib/tasks/rhconsulting_tags.rake
 	rm -f /var/www/miq/vmdb/lib/tasks/rhconsulting_reports.rake
+	rm -f /var/www/miq/vmdb/lib/tasks/rhconsulting_widgets.rake
 	rm -f /var/www/miq/vmdb/lib/tasks/rhconsulting_policies.rake
 	rm -f /usr/bin/miqexport
 	rm -f /usr/bin/miqimport
@@ -27,6 +28,7 @@ install:
 	install -Dm644 rhconsulting_service_catalogs.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_service_catalogs.rake
 	install -Dm644 rhconsulting_tags.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_tags.rake
 	install -Dm644 rhconsulting_reports.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_reports.rake
+	install -Dm644 rhconsulting_reports.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_widgets.rake
 	install -Dm644 rhconsulting_policies.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_policies.rake
 	install -Dm755 bin/miqexport /usr/bin/miqexport
 	install -Dm755 bin/miqimport /usr/bin/miqimport

--- a/README.adoc
+++ b/README.adoc
@@ -6,6 +6,8 @@ These scripts are useful to import/export specific items
 This can cause issues if you have two rake files with the same task names. For example, make sure there are not two instances of the dialogs:export. Even if you specify the namespace
 rake might choose the wrong task to run**
 
+IMPORTANT: Exporting and importing of widgets requires CloudForms 4.1 or ManageIQ Darga or greater releases.
+
 == Install
 
 Option 1) use make commands    
@@ -53,6 +55,7 @@ Available Object Types:
   buttons                          Export buttons.
   customization_templates          Export customization templates.
   reports                          Export custom reports.
+  widgets                          Export custom widgets.
   policies                         Export policies.
   domain <name>                    Export the specified domain from the
                                    Automate Engine Datastore. <name> MUST
@@ -86,6 +89,7 @@ Available Object Types:
   buttons                          Import buttons.
   customization_templates          Import customization templates.
   reports                          Import custom reports.
+  widgets                          Import custom widgets.
   policies                         Import policies.
   domain <name>                    Import the specified domain from the
                                    <importsource> directory. <name> MUST
@@ -120,7 +124,7 @@ BUILDDIR=/tmp/CFME-build
 DOMAIN_EXPORT=YourDomainHere
 
 rm -fR ${BUILDDIR}
-mkdir -p ${BUILDDIR}/{service_catalogs,dialogs,roles,tags,buttons,customization_templates,policies,miq_ae_datastore}
+mkdir -p ${BUILDDIR}/{service_catalogs,dialogs,roles,tags,buttons,customization_templates,policies,widgets,miq_ae_datastore}
 
 cd /var/www/miq/vmdb
 bin/rake rhconsulting:service_dialogs:export[${BUILDDIR}/dialogs]
@@ -130,6 +134,7 @@ bin/rake rhconsulting:tags:export[${BUILDDIR}/tags/tags.yml]
 bin/rake rhconsulting:buttons:export[${BUILDDIR}/buttons/buttons.yml]
 bin/rake rhconsulting:customization_templates:export[${BUILDDIR}/customization_templates/customization_templates.yml]
 bin/rake rhconsulting:miq_policies:export[${BUILDDIR}/policies]
+bin/rake rhconsulting:miq_widgets:export[${BUILDDIR}/widgets]
 bin/rake "rhconsulting:miq_ae_datastore:export[${DOMAIN_EXPORT}, ${BUILDDIR}/miq_ae_datastore]"
 ----
 
@@ -160,6 +165,7 @@ bin/rake rhconsulting:tags:import[${BUILDDIR}/tags/tags.yml]
 bin/rake rhconsulting:buttons:import[${BUILDDIR}/buttons/buttons.yml]
 bin/rake rhconsulting:customization_templates:import[${BUILDDIR}/customization_templates/customization_templates.yml]
 bin/rake rhconsulting:miq_policies:import[${BUILDDIR}/policies]
+bin/rake rhconsulting:miq_widgets:import[${BUILDDIR}/widgets]
 bin/rake rhconsulting:service_catalogs:import[${BUILDDIR}/service_catalogs]
 bin/rake "rhconsulting:miq_ae_datastore:import[${DOMAIN_IMPORT}, ${BUILDDIR}/miq_ae_datastore]"
 bin/rake rhconsulting:service_catalogs:import[${BUILDDIR}/service_catalogs]

--- a/bin/export-miqdomain
+++ b/bin/export-miqdomain
@@ -28,7 +28,7 @@ check_root()
 
 export ()
 {
-  mkdir -p ${BUILDDIR}/{service_catalogs,service_dialogs,roles,tags,buttons,customization_templates,reports,policies,miq_ae_datastore}
+  mkdir -p ${BUILDDIR}/{service_catalogs,service_dialogs,roles,tags,buttons,customization_templates,reports,widgets,policies,miq_ae_datastore}
 
   cd /var/www/miq/vmdb
   bin/rake rhconsulting:service_dialogs:export[${BUILDDIR}/service_dialogs]
@@ -37,6 +37,7 @@ export ()
   bin/rake rhconsulting:tags:export[${BUILDDIR}/tags/tags.yml]
   bin/rake rhconsulting:buttons:export[${BUILDDIR}/buttons/buttons.yml]
   bin/rake rhconsulting:miq_reports:export[${BUILDDIR}/reports]
+  bin/rake rhconsulting:miq_widgets:export[${BUILDDIR}/widgets]
   bin/rake rhconsulting:customization_templates:export[${BUILDDIR}/customization_templates/customization_templates.yml]
   bin/rake rhconsulting:miq_policies:export[${BUILDDIR}/policies]
   bin/rake "rhconsulting:miq_ae_datastore:export[${DOMAIN}, ${BUILDDIR}/miq_ae_datastore]"

--- a/bin/import-miqdomain
+++ b/bin/import-miqdomain
@@ -61,6 +61,7 @@ import()
   bin/rake rhconsulting:miq_policies:import[${DIR}/policies]
   bin/rake rhconsulting:service_catalogs:import[${DIR}/service_catalogs]
   bin/rake rhconsulting:miq_reports:import[${DIR}/reports]
+  bin/rake rhconsulting:miq_widgets:import[${DIR}/widgets]
   bin/rake "rhconsulting:miq_ae_datastore:import[${DOMAIN}, ${DIR}/miq_ae_datastore]"
   bin/rake rhconsulting:service_catalogs:import[${DIR}/service_catalogs]
 }

--- a/bin/miqexport
+++ b/bin/miqexport
@@ -29,6 +29,20 @@ op_reports () {
   popd
 }
 
+op_widgets () {
+  EXPORT_DIR=$1
+
+  if [ ! -d $EXPORT_DIR ]
+  then
+    echo "Export directory doesn't exist!"
+    exit 1
+  fi
+
+  pushd /var/www/miq/vmdb
+  bin/rake "rhconsulting:miq_widgets:export[${EXPORT_DIR}]"
+  popd
+}
+
 op_policies () {
   EXPORT_DIR=$1
 
@@ -176,6 +190,7 @@ Available Object Types:
   buttons                          Export buttons.
   customization_templates          Export customization templates.
   reports                          Export custom reports.
+  widgets                          Export custom widgets.
   policies                         Export policies.
   domain <name>                    Export the specified domain from the
                                    Automate Engine Datastore. <name> MUST

--- a/bin/miqimport
+++ b/bin/miqimport
@@ -29,6 +29,20 @@ op_reports () {
   popd
 }
 
+op_widgets () {
+  IMPORT_DIR=$1
+
+  if [ ! -d $IMPORT_DIR ]
+  then
+    echo "Import directory doesn't exist!"
+    exit 1
+  fi
+
+  pushd /var/www/miq/vmdb
+  bin/rake "rhconsulting:miq_widgets:import[${IMPORT_DIR}]"
+  popd
+}
+
 op_policies () {
   IMPORT_DIR=$1
 
@@ -176,6 +190,7 @@ Available Object Types:
   buttons                          Import buttons.
   customization_templates          Import customization templates.
   reports                          Import custom reports.
+  widgets                          Import custom widgets.
   policies                         Import policies.
   domain <name>                    Import the specified domain from the
                                    <importsource> directory. <name> MUST

--- a/cfme-rhconsulting-scripts.spec
+++ b/cfme-rhconsulting-scripts.spec
@@ -50,10 +50,10 @@ install --backup --mode=0755 -t "%{buildroot}/usr/bin" bin/import-miqdomain
 * Fri Jul 08 2016 Brant Evans <bevans@redhat.com> 0.6
 - Added export/import for widgets
 
-* Thu Apr 28 2015 Kumar Jadav <kumar.jadav@redhat.com> 0.5
+* Thu Apr 28 2016 Kumar Jadav <kumar.jadav@redhat.com> 0.5
 - Added the import-miqdomain file.
 
-* Tue Apr 26 2015 Kumar Jadav <kumar.jadav@redhat.com> 0.4
+* Tue Apr 26 2016 Kumar Jadav <kumar.jadav@redhat.com> 0.4
 - Added the export-miqdomain file.
 
 * Mon Dec 21 2015 George Goh <george.goh@redhat.com> 0.3-2

--- a/cfme-rhconsulting-scripts.spec
+++ b/cfme-rhconsulting-scripts.spec
@@ -1,6 +1,6 @@
 Name:      cfme-rhconsulting-scripts
-Version:   0.5
-Release:   2
+Version:   0.6
+Release:   1
 Summary:   Red Hat Consulting Scripts for CloudForms
 
 Group:     Applications/System
@@ -37,6 +37,7 @@ install --backup --mode=0755 -t "%{buildroot}/usr/bin" bin/import-miqdomain
 /var/www/miq/vmdb/lib/tasks/rhconsulting_dialogs.rake
 /var/www/miq/vmdb/lib/tasks/rhconsulting_service_catalogs.rake
 /var/www/miq/vmdb/lib/tasks/rhconsulting_reports.rake
+/var/www/miq/vmdb/lib/tasks/rhconsulting_widgets.rake
 /var/www/miq/vmdb/lib/tasks/rhconsulting_policies.rake
 /usr/bin/miqexport
 /usr/bin/miqimport
@@ -46,6 +47,9 @@ install --backup --mode=0755 -t "%{buildroot}/usr/bin" bin/import-miqdomain
 %post
 
 %changelog
+* Fri Jul 08 2016 Brant Evans <bevans@redhat.com> 0.6
+- Added export/import for widgets
+
 * Thu Apr 28 2015 Kumar Jadav <kumar.jadav@redhat.com> 0.5
 - Added the import-miqdomain file.
 

--- a/rhconsulting_widgets.rake
+++ b/rhconsulting_widgets.rake
@@ -1,0 +1,62 @@
+# Author: Brant Evans <bevans@redhat.com>
+
+class MiqWidgetsImportExport
+  class ParsedNonDialogYamlError < StandardError; end
+
+  def export(export_dir)
+    raise "Must supply export dir" if export_dir.blank?
+
+    # Export the Policies
+    export_widgets(export_dir)
+  end
+
+  def import(import_dir)
+    raise "Must supply import dir" if import_dir.blank?
+
+    # Import the Policy Profiles
+    import_widgets(import_dir)
+  end
+
+private
+
+  def export_widgets(export_dir)
+    custom_widgets = MiqWidget.find_all_by_read_only("false")
+    custom_widgets.each { |widget|
+      File.write("#{export_dir}/#{widget.id}_#{widget.title}.yaml", widget.export_to_array.to_yaml)
+    }
+  end
+
+  def import_widgets(import_dir)
+    MiqWidget.transaction do
+      Dir.glob("#{import_dir}/*yaml") do |filename|
+        widgets = YAML.load_file(filename)
+        widgets.each do |widget|
+          MiqWidget.import_from_hash(widget['MiqWidget'], {:userid=>'admin', :overwrite=>true, :save=>true})
+        end
+      end
+    end
+  end
+
+end
+
+namespace :rhconsulting do
+  namespace :miq_widgets do
+
+    desc 'Usage information'
+    task :usage => [:environment] do
+      puts 'Export - Usage: rake \'rhconsulting:miq_widgets:export[/path/to/dir/with/widgets]\''
+      puts 'Import - Usage: rake \'rhconsulting:miq_widgets:import[/path/to/dir/with/widgets]\''
+    end
+
+    desc 'Exports all widgets to individual YAML files'
+    task :export, [:filedir] => [:environment] do |_, arguments|
+      MiqWidgetsImportExport.new.export(arguments[:filedir])
+    end
+
+    desc 'Imports all policies from individual YAML files'
+    task :import, [:filedir] => [:environment] do |_, arguments|
+      MiqWidgetsImportExport.new.import(arguments[:filedir])
+    end
+
+  end
+end


### PR DESCRIPTION
This pull request adds a new script that will export and import report widgets. Importing widgets requires CloudForms 4.1 as [BZ1305719](https://bugzilla.redhat.com/show_bug.cgi?id=1305719) was fixed.