### PR TITLE
Fix calls to find_all_by_* that are no longer valid in CFME 5.6

### DIFF
--- a/rhconsulting_reports.rake
+++ b/rhconsulting_reports.rake
@@ -20,7 +20,7 @@ class MiqReportImportExport
 
   def export(export_dir)
     raise "Must supply export dir" if export_dir.blank?
-    custom_reports = MiqReport.find_all_by_rpt_type("Custom")
+    custom_reports = MiqReport.where(:rpt_type => "Custom")
     custom_reports.each { |report|
       File.write("#{export_dir}/#{report.id}_#{report.name.gsub('/', '_')}.yml", 
                  report.export_to_array.to_yaml)

--- a/rhconsulting_tags.rake
+++ b/rhconsulting_tags.rake
@@ -28,7 +28,7 @@ class TagImportExport
     if file_type == 'file'
       File.write(filename, Classification.export_to_yaml)
     elsif file_type == 'directory'
-      Classification.find_all_by_parent_id("0").each do |category|
+      Classification.where(:parent_id => "0").each do |category|
         # Skip exporting classifications where
         #   the classification does not show in the Web UI
         next if SPECIAL_TAGS.include?(category.name)

--- a/rhconsulting_widgets.rake
+++ b/rhconsulting_widgets.rake
@@ -20,7 +20,7 @@ class MiqWidgetsImportExport
 private
 
   def export_widgets(export_dir)
-    custom_widgets = MiqWidget.find_all_by_read_only("false")
+    custom_widgets = MiqWidget.where(:read_only => "false")
     custom_widgets.each { |widget|
       File.write("#{export_dir}/#{widget.id}_#{widget.title}.yaml", widget.export_to_array.to_yaml)
     }


### PR DESCRIPTION
In Rails 5 "find_all_by*" methods are no longer exposed
Implemenation of "where" used instead

Please review and merge