### PR TITLE
Add support for exporting and importing provisioning dialogs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.6
+VERSION := 0.8
 RELEASE := 1
 
 .PHONY: clean rpm install clean-install
@@ -6,7 +6,8 @@ RELEASE := 1
 rm-installed-files:
 	rm -f /var/www/miq/vmdb/lib/tasks/rhconsulting_buttons.rake
 	rm -f /var/www/miq/vmdb/lib/tasks/rhconsulting_customization_templates.rake
-	rm -f /var/www/miq/vmdb/lib/tasks/rhconsulting_dialogs.rake
+	rm -f /var/www/miq/vmdb/lib/tasks/rhconsulting_provision_dialogs.rake
+	rm -f /var/www/miq/vmdb/lib/tasks/rhconsulting_service_dialogs.rake
 	rm -f /var/www/miq/vmdb/lib/tasks/rhconsulting_miq_ae_datastore.rake
 	rm -f /var/www/miq/vmdb/lib/tasks/rhconsulting_roles.rake
 	rm -f /var/www/miq/vmdb/lib/tasks/rhconsulting_service_catalogs.rake
@@ -22,7 +23,8 @@ rm-installed-files:
 install:
 	install -Dm644 rhconsulting_buttons.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_buttons.rake
 	install -Dm644 rhconsulting_customization_templates.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_customization_templates.rake
-	install -Dm644 rhconsulting_dialogs.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_dialogs.rake
+	install -Dm644 rhconsulting_provision_dialogs.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_provision_dialogs.rake
+	install -Dm644 rhconsulting_service_dialogs.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_service_dialogs.rake
 	install -Dm644 rhconsulting_miq_ae_datastore.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_miq_ae_datastore.rake
 	install -Dm644 rhconsulting_roles.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_roles.rake
 	install -Dm644 rhconsulting_service_catalogs.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_service_catalogs.rake

--- a/README.adoc
+++ b/README.adoc
@@ -48,6 +48,7 @@ which may be a file or directory.
 exported.
 
 Available Object Types:
+  provision_dialogs                Export provisioning dialogs.
   service_dialogs                  Export service dialogs.
   service_catalogs                 Export service catalogs.
   roles                            Export user roles.
@@ -82,6 +83,7 @@ which may be a file or directory.
 imported.
 
 Available Object Types:
+  provision_dialogs                Import provisioning dialogs.
   service_dialogs                  Import service dialogs.
   service_catalogs                 Import service catalogs.
   roles                            Import user roles.
@@ -127,7 +129,8 @@ rm -fR ${BUILDDIR}
 mkdir -p ${BUILDDIR}/{service_catalogs,dialogs,roles,tags,buttons,customization_templates,policies,widgets,miq_ae_datastore}
 
 cd /var/www/miq/vmdb
-bin/rake rhconsulting:service_dialogs:export[${BUILDDIR}/dialogs]
+bin/rake rhconsulting:provision_dialogs:export[${BUILDDIR}/provision_dialogs]
+bin/rake rhconsulting:service_dialogs:export[${BUILDDIR}/service_dialogs]
 bin/rake rhconsulting:service_catalogs:export[${BUILDDIR}/service_catalogs]
 bin/rake rhconsulting:roles:export[${BUILDDIR}/roles/roles.yml]
 bin/rake rhconsulting:tags:export[${BUILDDIR}/tags/tags.yml]
@@ -159,7 +162,8 @@ BUILDDIR=/tmp/CFME-build
 DOMAIN_IMPORT=YourDomainHere
 
 cd /var/www/miq/vmdb
-bin/rake rhconsulting:service_dialogs:import[${BUILDDIR}/dialogs]
+bin/rake rhconsulting:provision_dialogs:import[${BUILDDIR}/provision_dialogs]
+bin/rake rhconsulting:service_dialogs:import[${BUILDDIR}/service_dialogs]
 bin/rake rhconsulting:roles:import[${BUILDDIR}/roles/roles.yml]
 bin/rake rhconsulting:tags:import[${BUILDDIR}/tags/tags.yml]
 bin/rake rhconsulting:buttons:import[${BUILDDIR}/buttons/buttons.yml]

--- a/bin/export-miqdomain
+++ b/bin/export-miqdomain
@@ -31,6 +31,7 @@ export ()
   mkdir -p ${BUILDDIR}/{service_catalogs,service_dialogs,roles,tags,buttons,customization_templates,reports,widgets,policies,miq_ae_datastore}
 
   cd /var/www/miq/vmdb
+  bin/rake rhconsulting:provision_dialogs:export[${BUILDDIR}/provision_dialogs]
   bin/rake rhconsulting:service_dialogs:export[${BUILDDIR}/service_dialogs]
   bin/rake rhconsulting:service_catalogs:export[${BUILDDIR}/service_catalogs]
   bin/rake rhconsulting:roles:export[${BUILDDIR}/roles/roles.yml]

--- a/bin/import-miqdomain
+++ b/bin/import-miqdomain
@@ -53,6 +53,7 @@ domain_name()
 import()
 {
   cd /var/www/miq/vmdb
+  bin/rake rhconsulting:provision_dialogs:import[${DIR}/provision_dialogs]
   bin/rake rhconsulting:service_dialogs:import[${DIR}/service_dialogs]
   bin/rake rhconsulting:roles:import[${DIR}/roles/roles.yml]
   bin/rake rhconsulting:tags:import[${DIR}/tags/tags.yml]

--- a/bin/miqexport
+++ b/bin/miqexport
@@ -57,7 +57,21 @@ op_policies () {
   popd
 }
 
-op_dialogs () {
+op_provision_dialogs () {
+  EXPORT_DIR=$1
+
+  if [ ! -d $EXPORT_DIR ]
+  then
+    echo "Export directory doesn't exist!"
+    exit 1
+  fi
+
+  pushd /var/www/miq/vmdb
+  bin/rake "rhconsulting:provision_dialogs:export[${EXPORT_DIR}]"
+  popd
+}
+
+op_service_dialogs () {
   EXPORT_DIR=$1
 
   if [ ! -d $EXPORT_DIR ]
@@ -183,7 +197,8 @@ which may be a file or directory.
 exported.
 
 Available Object Types:
-  dialogs                          Export service dialogs.
+  provision_dialogs                Export provisioning dialogs.
+  service_dialogs                  Export service dialogs.
   service_catalogs                 Export service catalogs.
   roles                            Export user roles.
   tags                             Export tags.

--- a/bin/miqimport
+++ b/bin/miqimport
@@ -57,7 +57,21 @@ op_policies () {
   popd
 }
 
-op_dialogs () {
+op_provision_dialogs () {
+  IMPORT_DIR=$1
+
+  if [ ! -d $IMPORT_DIR ]
+  then
+    echo "Import directory doesn't exist!"
+    exit 1
+  fi
+
+  pushd /var/www/miq/vmdb
+  bin/rake "rhconsulting:provision_dialogs:import[${IMPORT_DIR}]"
+  popd
+}
+
+op_service_dialogs () {
   IMPORT_DIR=$1
 
   if [ ! -d $IMPORT_DIR ]
@@ -183,7 +197,8 @@ which may be a file or directory.
 imported.
 
 Available Object Types:
-  dialogs                          Import service dialogs.
+  provision_dialogs                Import provisioning dialogs.
+  service_dialogs                  Import service dialogs.
   service_catalogs                 Import service catalogs.
   roles                            Import user roles.
   tags                             Import tags.

--- a/cfme-rhconsulting-scripts.spec
+++ b/cfme-rhconsulting-scripts.spec
@@ -1,5 +1,5 @@
 Name:      cfme-rhconsulting-scripts
-Version:   0.6
+Version:   0.8
 Release:   1
 Summary:   Red Hat Consulting Scripts for CloudForms
 
@@ -34,7 +34,8 @@ install --backup --mode=0755 -t "%{buildroot}/usr/bin" bin/import-miqdomain
 /var/www/miq/vmdb/lib/tasks/rhconsulting_tags.rake
 /var/www/miq/vmdb/lib/tasks/rhconsulting_customization_templates.rake
 /var/www/miq/vmdb/lib/tasks/rhconsulting_roles.rake
-/var/www/miq/vmdb/lib/tasks/rhconsulting_dialogs.rake
+/var/www/miq/vmdb/lib/tasks/rhconsulting_provision_dialogs.rake
+/var/www/miq/vmdb/lib/tasks/rhconsulting_service_dialogs.rake
 /var/www/miq/vmdb/lib/tasks/rhconsulting_service_catalogs.rake
 /var/www/miq/vmdb/lib/tasks/rhconsulting_reports.rake
 /var/www/miq/vmdb/lib/tasks/rhconsulting_widgets.rake
@@ -47,6 +48,9 @@ install --backup --mode=0755 -t "%{buildroot}/usr/bin" bin/import-miqdomain
 %post
 
 %changelog
+* Mon Aug 15 2016 Brant Evans <bevans@redhat.com> 0.8
+- Added export/import for provisioning dialogs
+
 * Fri Jul 08 2016 Brant Evans <bevans@redhat.com> 0.6
 - Added export/import for widgets
 

--- a/rhconsulting_provision_dialogs.rake
+++ b/rhconsulting_provision_dialogs.rake
@@ -1,0 +1,90 @@
+# Heavily based on a rails script written by Dustin Scott <dscott@redhat.com>
+# Author: Brant Evans <bevans@redhat.com>
+
+class ProvisionDialogImportExport
+  class ParsedNonDialogYamlError < StandardError; end
+
+  def export(filedir)
+    # Do some basic checks
+    raise "Must supply export directory" if filedir.blank?
+    raise "#{filedir} does not exist" if ! File.exist?(filedir)
+    raise "#{filedir} is not a directory" if ! File.directory?(filedir)
+    raise "#{filedir} is not a writable" if ! File.writable?(filedir)
+
+    # Get the provision dialogs to export
+    dialog_array = export_prov_dialogs
+
+    # Save provision dialogs
+    dialog_array.each do |dialog|
+      # Set the filename and replace characters that are not allowed in filenames
+      fname = "#{dialog[:name]}.yaml".gsub(%r{[|/]}, "_")
+
+      File.write("#{filedir}/#{fname}", dialog.to_yaml)
+    end
+  end
+
+  def import(import_name)
+    raise "Must supply filename or directory" if import_name.blank?
+    if File.file?(import_name)
+      dialog = YAML.load_file(import_name)
+      import_prov_dialogs(dialog)
+    elsif File.directory?(import_name)
+      Dir.glob("#{import_name}/*.yaml") do |fname|
+        dialog = YAML.load_file(fname)
+        import_prov_dialogs(dialog)
+      end
+    else
+      raise "Argument is not a filename or directory"
+    end
+  end
+
+  private
+
+  def export_prov_dialogs
+    dialog_array = []
+    # Only export non-default dialogs
+    MiqDialog.order(:id).where(:default => false).each do |dialog|
+      dialog_hash = dialog.to_model_hash
+      # Delete keys that are not needed. These will be recreated on import
+      [ :class, :id, :created_at, :updated_at ].each { |key| dialog_hash.delete(key) }
+      # Put the resulting hash in our array to return
+      dialog_array << dialog_hash
+    end
+    # Return the array
+    dialog_array
+  end
+
+  def import_prov_dialogs(dialog)
+    # Check if there is already a dialog with the same name that is being imported
+    model_dialog = MiqDialog.where(:name => dialog[:name]).first
+
+    # If an existing dialog was found update it otherwise create a new dialog
+    if model_dialog.nil? then
+      MiqDialog.create(dialog)
+    else
+      model_dialog.update(dialog)
+    end
+  end
+end
+
+namespace :rhconsulting do
+  namespace :provision_dialogs do
+
+    desc 'Usage information'
+    task :usage => [:environment] do
+      puts 'Export - Usage: rake rhconsulting:provision_dialogs:export[/path/to/dir/with/dialogs]'
+      puts 'Import - Usage: rake rhconsulting:provision_dialogs:import[/path/to/dir/with/dialogs]'
+    end
+
+    desc 'Import all provisioning dialogs to individual YAML files'
+    task :import, [:filedir] => [:environment] do |_, arguments|
+      ProvisionDialogImportExport.new.import(arguments[:filedir])
+    end
+
+    desc 'Exports all provisioning dialogs to individual YAML files'
+    task :export, [:filedir] => [:environment] do |_, arguments|
+      ProvisionDialogImportExport.new.export(arguments[:filedir])
+    end
+
+  end
+end

--- a/rhconsulting_service_dialogs.rake
+++ b/rhconsulting_service_dialogs.rake
@@ -1,4 +1,4 @@
-class DialogImportExport
+class ServiceDialogImportExport
   class ParsedNonDialogYamlError < StandardError; end
 
   def export(filedir)
@@ -150,14 +150,14 @@ namespace :rhconsulting do
       puts 'Import - Usage: rake rhconsulting:service_dialogs:import[/path/to/dir/with/dialogs]'
     end
 
-    desc 'Import all dialogs to individual YAML files'
+    desc 'Import all service dialogs to individual YAML files'
     task :import, [:filedir] => [:environment] do |_, arguments|
-      DialogImportExport.new.import(arguments[:filedir])
+      ServiceDialogImportExport.new.import(arguments[:filedir])
     end
 
-    desc 'Exports all dialogs to individual YAML files'
+    desc 'Exports all service dialogs to individual YAML files'
     task :export, [:filedir] => [:environment] do |_, arguments|
-      DialogImportExport.new.export(arguments[:filedir])
+      ServiceDialogImportExport.new.export(arguments[:filedir])
     end
 
   end


### PR DESCRIPTION
This PR adds support for exporting and importing provisioning dialogs. The service dialogs filename, class, and namespace have been updated to differentiate between service and provisioning dialogs.

This has been tested with CF 4.1