### PR TITLE
Corrected examples

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,7 +10,7 @@ IMPORTANT: Exporting and importing of widgets requires CloudForms 4.1 or ManageI
 
 == Install
 
-Option 1) use make commands    
+Option 1) use make commands
 
 * Get latest files from github
 ----
@@ -70,8 +70,8 @@ Available Object Types:
 # export the 'MyCustomDomain' to /tmp, i.e., /tmp/MyCustomDomain
 miqexport domain MyCustomDomain /tmp
 
-# export dialogs to /tmp/dialogs
-miqexport dialogs /tmp/dialogs
+# export service dialogs to /tmp/dialogs
+miqexport service_dialogs /tmp/dialogs
 ----
 
 == Import Command
@@ -107,14 +107,14 @@ Available Object Types:
 # import 'MyCustomDomain' from /tmp, i.e., /tmp/MyCustomDomain
 miqimport domain MyCustomDomain /tmp
 
-# import dialogs from /tmp/dialogs
-miqimport dialogs /tmp/dialogs
+# import service dialogs from /tmp/dialogs
+miqimport service_dialogs /tmp/dialogs
 ----
 
 == Export examples using rake
 * You can do the export by using the `export-miqdomain` script or manually as well.
 ----
-export-domain 
+export-domain
 Usage: ./export-domain -d CloudFormsDomain -D /path/to/the/directory
 
 OPTIONS:
@@ -149,10 +149,10 @@ bin/rake "rhconsulting:miq_ae_datastore:export[${DOMAIN_EXPORT}, ${BUILDDIR}/miq
 
 == Import examples using rake
 
-* You can do the import by using the `import-miqdomain` script or manually as well. 
+* You can do the import by using the `import-miqdomain` script or manually as well.
 
 ----
-import-miqdomain 
+import-miqdomain
 Usage: ./import-miqdomain -D /absolute/path/to/the/directory
 
 OPTIONS:
@@ -195,4 +195,3 @@ NOTE: Service Catalogs should be imported last as they reference Dialogs and the
 * Lester Claudio (claudiol@redhat.com)
 * George Goh (george.goh@redhat.com)
 * Brant Evans (bevans@redhat.com)
-


### PR DESCRIPTION
The example says 'dialogs' instead of service/catalog dialogs, this
may cause confusion. One of the customer tried with 'dialogs' and
failed. This patch corrects import/export example commands.