### PR TITLE
Added support for: individual files, names with spaces, relative paths and symlinks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,9 @@ install:
 	install -Dm755 bin/export-miqdomain /usr/bin/export-miqdomain
 	install -Dm755 bin/import-miqdomain /usr/bin/import-miqdomain
 
-clean-install: rm-installed-files install
+uninstall: rm-installed-files
 
+clean-install: rm-installed-files install
 
 TARBALL := $(shell rpmbuild -E %{_sourcedir})/cfme-rhconsulting-scripts-$(VERSION)-$(RELEASE).tar.gz
 

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ rpm:
 	rm -rf cfme-consulting-scripts && \
 	mkdir -p cfme-rhconsulting-scripts/bin && \
 	cp *.rake cfme-rhconsulting-scripts && \
+	cp *.rb cfme-rhconsulting-scripts && \
 	cp bin/* cfme-rhconsulting-scripts/bin && \
 	tar zcf "$(TARBALL)" cfme-rhconsulting-scripts && \
 	rm -rf cfme-rhconsulting-scripts && \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-VERSION := 0.8
-RELEASE := 2
+VERSION := 0.9
+RELEASE := 1
 
 .PHONY: clean rpm install clean-install
 
@@ -16,6 +16,8 @@ rm-installed-files:
 	rm -f /var/www/miq/vmdb/lib/tasks/rhconsulting_widgets.rake
 	rm -f /var/www/miq/vmdb/lib/tasks/rhconsulting_policies.rake
 	rm -f /var/www/miq/vmdb/lib/tasks/rhconsulting_alerts.rake
+	rm -f /var/www/miq/vmdb/lib/tasks/rhconsulting_illegal_chars.rb
+	rm -f /var/www/miq/vmdb/lib/tasks/rhconsulting_options.rb
 	rm -f /usr/bin/miqexport
 	rm -f /usr/bin/miqimport
 	rm -f /usr/bin/export-miqdomain
@@ -31,9 +33,11 @@ install:
 	install -Dm644 rhconsulting_service_catalogs.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_service_catalogs.rake
 	install -Dm644 rhconsulting_tags.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_tags.rake
 	install -Dm644 rhconsulting_reports.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_reports.rake
-	install -Dm644 rhconsulting_reports.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_widgets.rake
+	install -Dm644 rhconsulting_widgets.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_widgets.rake
 	install -Dm644 rhconsulting_policies.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_policies.rake
-	install -Dm644 rhconsulting_policies.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_alerts.rake
+	install -Dm644 rhconsulting_alerts.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_alerts.rake
+	install -Dm644 rhconsulting_illegal_chars.rb /var/www/miq/vmdb/lib/tasks/rhconsulting_illegal_chars.rb
+	install -Dm644 rhconsulting_options.rb /var/www/miq/vmdb/lib/tasks/rhconsulting_options.rb
 	install -Dm755 bin/miqexport /usr/bin/miqexport
 	install -Dm755 bin/miqimport /usr/bin/miqimport
 	install -Dm755 bin/export-miqdomain /usr/bin/export-miqdomain

--- a/README.adoc
+++ b/README.adoc
@@ -65,6 +65,9 @@ Available Object Types:
                                    be specified.
 ----
 
+*Note* As of version 0.9 spaces in exported filenames will be replaced with
+underscores. To preserve the old behavior 
+
 == Example exports
 ----
 # export the 'MyCustomDomain' to /tmp, i.e., /tmp/MyCustomDomain

--- a/README.adoc
+++ b/README.adoc
@@ -63,10 +63,17 @@ Available Object Types:
   domain <name>                    Export the specified domain from the
                                    Automate Engine Datastore. <name> MUST
                                    be specified.
+                                   
+Options:
+  -s, --keep-spaces                Export filenames with spaces instead of
+                                   replacing the spaces with underscores.
+                                   (this preserves old behavior)
 ----
 
-*Note* As of version 0.9 spaces in exported filenames will be replaced with
-underscores. To preserve the old behavior 
+**Note:
+As of version 0.9 spaces in exported filenames are be replaced with
+underscores. To preserve the old behavior and keep spaces in the filenames
+pass in `-s` or `--keep-spaces` to the miqexport script.**
 
 == Example exports
 ----

--- a/bin/export-miqdomain
+++ b/bin/export-miqdomain
@@ -28,21 +28,21 @@ check_root()
 
 export ()
 {
-  mkdir -p ${BUILDDIR}/{service_catalogs,service_dialogs,roles,tags,buttons,customization_templates,reports,widgets,policies,alerts,alertsets,miq_ae_datastore}
+  mkdir -p "${BUILDDIR}"/{provision_dialogs,service_catalogs,service_dialogs,roles,tags,buttons,customization_templates,reports,widgets,policies,alerts,alertsets,miq_ae_datastore}
 
   cd /var/www/miq/vmdb
-  bin/rake rhconsulting:provision_dialogs:export[${BUILDDIR}/provision_dialogs]
-  bin/rake rhconsulting:service_dialogs:export[${BUILDDIR}/service_dialogs]
-  bin/rake rhconsulting:service_catalogs:export[${BUILDDIR}/service_catalogs]
-  bin/rake rhconsulting:roles:export[${BUILDDIR}/roles/roles.yml]
-  bin/rake rhconsulting:tags:export[${BUILDDIR}/tags/tags.yml]
-  bin/rake rhconsulting:buttons:export[${BUILDDIR}/buttons/buttons.yml]
-  bin/rake rhconsulting:miq_reports:export[${BUILDDIR}/reports]
-  bin/rake rhconsulting:miq_widgets:export[${BUILDDIR}/widgets]
-  bin/rake rhconsulting:customization_templates:export[${BUILDDIR}/customization_templates/customization_templates.yml]
-  bin/rake rhconsulting:miq_policies:export[${BUILDDIR}/policies]
-  bin/rake rhconsulting:miq_alerts:export[${BUILDDIR}/alerts]
-  bin/rake rhconsulting:miq_alertsets:export[${BUILDDIR}/alertsets]
+  bin/rake rhconsulting:provision_dialogs:export["${BUILDDIR}/provision_dialogs"]
+  bin/rake rhconsulting:service_dialogs:export["${BUILDDIR}/service_dialogs"]
+  bin/rake rhconsulting:service_catalogs:export["${BUILDDIR}/service_catalogs"]
+  bin/rake rhconsulting:roles:export["${BUILDDIR}/roles/roles.yml"]
+  bin/rake rhconsulting:tags:export["${BUILDDIR}/tags/tags.yml"]
+  bin/rake rhconsulting:buttons:export["${BUILDDIR}/buttons/buttons.yml"]
+  bin/rake rhconsulting:miq_reports:export["${BUILDDIR}/reports"]
+  bin/rake rhconsulting:miq_widgets:export["${BUILDDIR}/widgets"]
+  bin/rake rhconsulting:customization_templates:export["${BUILDDIR}/customization_templates/customization_templates.yml"]
+  bin/rake rhconsulting:miq_policies:export["${BUILDDIR}/policies"]
+  bin/rake rhconsulting:miq_alerts:export["${BUILDDIR}/alerts"]
+  bin/rake rhconsulting:miq_alertsets:export["${BUILDDIR}/alertsets"]
   bin/rake "rhconsulting:miq_ae_datastore:export[${DOMAIN}, ${BUILDDIR}/miq_ae_datastore]"
 }
 
@@ -56,10 +56,10 @@ while getopts "d:,D:,:h" opts; do
       exit 1
       ;;
     d)
-      DOMAIN=${OPTARG}
+      DOMAIN="$OPTARG"
       ;;
     D)
-      BUILDDIR=${OPTARG}
+      BUILDDIR="$OPTARG"
       ;;
     \?)
       echo "Invalid option -$OPTARG" >&2
@@ -74,7 +74,7 @@ while getopts "d:,D:,:h" opts; do
   esac
 done
 
-if [[ -z ${DOMAIN} ]] || [[ -z ${BUILDDIR} ]]; then
+if [[ -z "${DOMAIN}" ]] || [[ -z "${BUILDDIR}" ]]; then
   usage
   exit 1
 fi

--- a/bin/export-miqdomain
+++ b/bin/export-miqdomain
@@ -43,7 +43,7 @@ export ()
   bin/rake rhconsulting:miq_policies:export["${BUILDDIR}/policies"]
   bin/rake rhconsulting:miq_alerts:export["${BUILDDIR}/alerts"]
   bin/rake rhconsulting:miq_alertsets:export["${BUILDDIR}/alertsets"]
-  bin/rake "rhconsulting:miq_ae_datastore:export[${DOMAIN}, ${BUILDDIR}/miq_ae_datastore]"
+  bin/rake "rhconsulting:miq_ae_datastore:export[${DOMAIN},${BUILDDIR}/miq_ae_datastore]"
 }
 
 

--- a/bin/import-miqdomain
+++ b/bin/import-miqdomain
@@ -65,7 +65,7 @@ import()
   bin/rake rhconsulting:service_catalogs:import["${DIR}"/service_catalogs]
   bin/rake rhconsulting:miq_reports:import["${DIR}"/reports]
   bin/rake rhconsulting:miq_widgets:import["${DIR}"/widgets]
-  bin/rake "rhconsulting:miq_ae_datastore:import[${DOMAIN}, ${DIR}/miq_ae_datastore]"
+  bin/rake "rhconsulting:miq_ae_datastore:import[${DOMAIN},${DIR}/miq_ae_datastore]"
   bin/rake rhconsulting:service_catalogs:import["${DIR}"/service_catalogs]
 }
 

--- a/bin/import-miqdomain
+++ b/bin/import-miqdomain
@@ -28,7 +28,7 @@ absolute_path()
 
 check_root()
 {
-  if [[ ${EUID} != 0 ]]; then
+  if [[ "${EUID}" != 0 ]]; then
     echo "Error: Run the $0 as 'root'." >&2
     exit 1
   fi
@@ -36,7 +36,7 @@ check_root()
 
 check_directory()
 {
-  if [[ ! -d ${DIR} ]]; then
+  if [[ ! -d "${DIR}" ]]; then
     echo "Error: The directory does not exist." >&2
     exit 1
   fi
@@ -45,28 +45,28 @@ check_directory()
 
 domain_name()
 {
-  DIRECTORY=`find ${DIR}/miq_ae_datastore/ -maxdepth 1 -type d | tail -1`
-  DOMAIN=`basename ${DIRECTORY}`
+  DIRECTORY=`find "${DIR}"/miq_ae_datastore/ -maxdepth 1 -type d | tail -1`
+  DOMAIN=`basename "${DIRECTORY}"`
   echo "Domain name to be imported is ${DOMAIN}"
 }
 
 import()
 {
   cd /var/www/miq/vmdb
-  bin/rake rhconsulting:provision_dialogs:import[${DIR}/provision_dialogs]
-  bin/rake rhconsulting:service_dialogs:import[${DIR}/service_dialogs]
-  bin/rake rhconsulting:roles:import[${DIR}/roles/roles.yml]
-  bin/rake rhconsulting:tags:import[${DIR}/tags/tags.yml]
-  bin/rake rhconsulting:buttons:import[${DIR}/buttons/buttons.yml]
-  bin/rake rhconsulting:customization_templates:import[${DIR}/customization_templates/customization_templates.yml]
-  bin/rake rhconsulting:miq_policies:import[${DIR}/policies]
-  bin/rake rhconsulting:miq_alerts:import[${DIR}/alerts]
-  bin/rake rhconsulting:miq_alertsets:import[${DIR}/alertsets]
-  bin/rake rhconsulting:service_catalogs:import[${DIR}/service_catalogs]
-  bin/rake rhconsulting:miq_reports:import[${DIR}/reports]
-  bin/rake rhconsulting:miq_widgets:import[${DIR}/widgets]
+  bin/rake rhconsulting:provision_dialogs:import["${DIR}"/provision_dialogs]
+  bin/rake rhconsulting:service_dialogs:import["${DIR}"/service_dialogs]
+  bin/rake rhconsulting:roles:import["${DIR}"/roles/roles.yml]
+  bin/rake rhconsulting:tags:import["${DIR}"/tags/tags.yml]
+  bin/rake rhconsulting:buttons:import["${DIR}"/buttons/buttons.yml]
+  bin/rake rhconsulting:customization_templates:import["${DIR}"/customization_templates/customization_templates.yml]
+  bin/rake rhconsulting:miq_policies:import["${DIR}"/policies]
+  bin/rake rhconsulting:miq_alerts:import["${DIR}"/alerts]
+  bin/rake rhconsulting:miq_alertsets:import["${DIR}"/alertsets]
+  bin/rake rhconsulting:service_catalogs:import["${DIR}"/service_catalogs]
+  bin/rake rhconsulting:miq_reports:import["${DIR}"/reports]
+  bin/rake rhconsulting:miq_widgets:import["${DIR}"/widgets]
   bin/rake "rhconsulting:miq_ae_datastore:import[${DOMAIN}, ${DIR}/miq_ae_datastore]"
-  bin/rake rhconsulting:service_catalogs:import[${DIR}/service_catalogs]
+  bin/rake rhconsulting:service_catalogs:import["${DIR}"/service_catalogs]
 }
 
 
@@ -79,7 +79,7 @@ while getopts "D:,:h" opts; do
       exit 1
       ;;
     D)
-      DIR=${OPTARG}
+      DIR="${OPTARG}"
       ;;
     \?)
       echo "Invalid option -$OPTARG" >&2
@@ -94,7 +94,7 @@ while getopts "D:,:h" opts; do
   esac
 done
 
-if [[ -z ${DIR} ]]; then
+if [[ -z "${DIR}" ]]; then
   usage
   exit 1
 fi

--- a/bin/miqexport
+++ b/bin/miqexport
@@ -2,7 +2,7 @@
 
 op_domain () {
   DOMAIN_NAME=$1
-  EXPORT_DIR=$2
+  EXPORT_DIR=$(readlink -v -f $2)
 
   if [ ! -d "$EXPORT_DIR" ]
   then
@@ -16,7 +16,7 @@ op_domain () {
 }
 
 op_reports () {
-  EXPORT_DIR=$1
+  EXPORT_DIR=$(readlink -v -f $1)
 
   if [ ! -d "$EXPORT_DIR" ]
   then
@@ -30,7 +30,7 @@ op_reports () {
 }
 
 op_widgets () {
-  EXPORT_DIR=$1
+  EXPORT_DIR=$(readlink -v -f $1)
 
   if [ ! -d "$EXPORT_DIR" ]
   then
@@ -44,7 +44,7 @@ op_widgets () {
 }
 
 op_alerts () {
-  EXPORT_DIR=$1
+  EXPORT_DIR=$(readlink -v -f $1)
 
   if [ ! -d "$EXPORT_DIR" ]
   then
@@ -58,7 +58,7 @@ op_alerts () {
 }
 
 op_alertsets () {
-  EXPORT_DIR=$1
+  EXPORT_DIR=$(readlink -v -f $1)
 
   if [ ! -d "$EXPORT_DIR" ]
   then
@@ -72,7 +72,7 @@ op_alertsets () {
 }
 
 op_policies () {
-  EXPORT_DIR=$1
+  EXPORT_DIR=$(readlink -v -f $1)
 
   if [ ! -d "$EXPORT_DIR" ]
   then
@@ -86,7 +86,7 @@ op_policies () {
 }
 
 op_provision_dialogs () {
-  EXPORT_DIR=$1
+  EXPORT_DIR=$(readlink -v -f $1)
 
   if [ ! -d "$EXPORT_DIR" ]
   then
@@ -100,7 +100,7 @@ op_provision_dialogs () {
 }
 
 op_service_dialogs () {
-  EXPORT_DIR=$1
+  EXPORT_DIR=$(readlink -v -f $1)
 
   if [ ! -d "$EXPORT_DIR" ]
   then
@@ -114,7 +114,7 @@ op_service_dialogs () {
 }
 
 op_service_catalogs () {
-  EXPORT_DIR=$1
+  EXPORT_DIR=$(readlink -v -f $1)
 
   if [ ! -d "$EXPORT_DIR" ]
   then
@@ -128,7 +128,7 @@ op_service_catalogs () {
 }
 
 op_roles () {
-  EXPORT_FILE=$1
+  EXPORT_FILE=$(readlink -v -f $1)
   EXPORT_DIR=$(dirname "$EXPORT_FILE")
 
   if [ ! -d "$EXPORT_DIR" ]
@@ -143,7 +143,7 @@ op_roles () {
 }
 
 op_tags () {
-  EXPORT_FILE=$1
+  EXPORT_FILE=$(readlink -v -f $1)
   EXPORT_DIR=$(dirname "$EXPORT_FILE")
 
   if [ ! -d "$EXPORT_DIR" ]
@@ -158,7 +158,7 @@ op_tags () {
 }
 
 op_buttons () {
-  EXPORT_FILE=$1
+  EXPORT_FILE=$(readlink -v -f $1)
   EXPORT_DIR=$(dirname "$EXPORT_FILE")
 
   if [ ! -d "$EXPORT_DIR" ]
@@ -173,7 +173,7 @@ op_buttons () {
 }
 
 op_customization_templates () {
-  EXPORT_FILE=$1
+  EXPORT_FILE=$(readlink -v -f $1)
   EXPORT_DIR=$(dirname "$EXPORT_FILE")
 
   if [ ! -d "$EXPORT_DIR" ]

--- a/bin/miqexport
+++ b/bin/miqexport
@@ -87,7 +87,7 @@ op_provision_dialogs () {
   assert_export_dir_exists "$EXPORT_DIR"
 
   pushd /var/www/miq/vmdb
-  bin/rake --trace "rhconsulting:provision_dialogs:export[${EXPORT_DIR},keep_spaces=${KEEP_SPACES}]"
+  bin/rake "rhconsulting:provision_dialogs:export[${EXPORT_DIR},keep_spaces=${KEEP_SPACES}]"
   popd
 }
 

--- a/bin/miqexport
+++ b/bin/miqexport
@@ -1,70 +1,70 @@
 #!/usr/bin/env bash
 
-op_domain () {
-  DOMAIN_NAME=$1
-  EXPORT_DIR=$(readlink -v -f "$2")
-
-  if [ ! -d "$EXPORT_DIR" ]
+assert_num_args () {
+  num_args_received=$1
+  num_args_expected=$2
+  if [ "$num_args_received" -ne "$num_args_expected" ]
   then
-    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
+    echo "Error: Wrong number of arguments (expected=$num_args_expected received=$num_args_received)"
+    usage
     exit 1
   fi
+}
 
+assert_export_dir_exists () {
+  export_dir=$1
+  if [ ! -d "$export_dir" ]
+  then
+    echo "Export directory doesn't exist! [${export_dir}]"
+    exit 1
+  fi
+}
+
+op_domain () {
+  assert_num_args $# 2
+  DOMAIN_NAME=$1
+  EXPORT_DIR=$(readlink -v -f "$2")
+  assert_export_dir_exists "$EXPORT_DIR"
+  
   pushd /var/www/miq/vmdb
-  bin/rake "rhconsulting:miq_ae_datastore:export[${DOMAIN_NAME}, ${EXPORT_DIR}]"
+  bin/rake "rhconsulting:miq_ae_datastore:export[${DOMAIN_NAME},${EXPORT_DIR}]"
   popd
 }
 
 op_reports () {
+  assert_num_args $# 1
   EXPORT_DIR=$(readlink -v -f "$1")
-
-  if [ ! -d "$EXPORT_DIR" ]
-  then
-    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
-    exit 1
-  fi
-
+  assert_export_dir_exists "$EXPORT_DIR"
+  
   pushd /var/www/miq/vmdb
-  bin/rake "rhconsulting:miq_reports:export[${EXPORT_DIR}]"
+  bin/rake "rhconsulting:miq_reports:export[${EXPORT_DIR},keep_spaces=${KEEP_SPACES}]"
   popd
 }
 
 op_widgets () {
+  assert_num_args $# 1
   EXPORT_DIR=$(readlink -v -f "$1")
-
-  if [ ! -d "$EXPORT_DIR" ]
-  then
-    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
-    exit 1
-  fi
-
+  assert_export_dir_exists "$EXPORT_DIR"
+  
   pushd /var/www/miq/vmdb
-  bin/rake "rhconsulting:miq_widgets:export[${EXPORT_DIR}]"
+  bin/rake "rhconsulting:miq_widgets:export[${EXPORT_DIR},keep_spaces=${KEEP_SPACES}]"
   popd
 }
 
 op_alerts () {
+  assert_num_args $# 1
   EXPORT_DIR=$(readlink -v -f "$1")
-
-  if [ ! -d "$EXPORT_DIR" ]
-  then
-    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
-    exit 1
-  fi
-
+  assert_export_dir_exists "$EXPORT_DIR"
+  
   pushd /var/www/miq/vmdb
-  bin/rake "rhconsulting:miq_alerts:export[${EXPORT_DIR}]"
+  bin/rake "rhconsulting:miq_alerts:export[${EXPORT_DIR},keep_spaces=${KEEP_SPACES}]"
   popd
 }
 
 op_alertsets () {
+  assert_num_args $# 1
   EXPORT_DIR=$(readlink -v -f "$1")
-
-  if [ ! -d "$EXPORT_DIR" ]
-  then
-    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
-    exit 1
-  fi
+  assert_export_dir_exists "$EXPORT_DIR"
 
   pushd /var/www/miq/vmdb
   bin/rake "rhconsulting:miq_alertsets:export[${EXPORT_DIR}]"
@@ -72,118 +72,86 @@ op_alertsets () {
 }
 
 op_policies () {
+  assert_num_args $# 1
   EXPORT_DIR=$(readlink -v -f "$1")
-
-  if [ ! -d "$EXPORT_DIR" ]
-  then
-    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
-    exit 1
-  fi
+  assert_export_dir_exists "$EXPORT_DIR"
 
   pushd /var/www/miq/vmdb
-  bin/rake "rhconsulting:miq_policies:export[${EXPORT_DIR}]"
+  bin/rake "rhconsulting:miq_policies:export[${EXPORT_DIR},keep_spaces=${KEEP_SPACES}]"
   popd
 }
 
 op_provision_dialogs () {
+  assert_num_args $# 1
   EXPORT_DIR=$(readlink -v -f "$1")
-
-  if [ ! -d "$EXPORT_DIR" ]
-  then
-    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
-    exit 1
-  fi
+  assert_export_dir_exists "$EXPORT_DIR"
 
   pushd /var/www/miq/vmdb
-  bin/rake --trace "rhconsulting:provision_dialogs:export[${EXPORT_DIR}]"
+  bin/rake --trace "rhconsulting:provision_dialogs:export[${EXPORT_DIR},keep_spaces=${KEEP_SPACES}]"
   popd
 }
 
 op_service_dialogs () {
+  assert_num_args $# 1
   EXPORT_DIR=$(readlink -v -f "$1")
-
-  if [ ! -d "$EXPORT_DIR" ]
-  then
-    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
-    exit 1
-  fi
+  assert_export_dir_exists "$EXPORT_DIR"
 
   pushd /var/www/miq/vmdb
-  bin/rake "rhconsulting:service_dialogs:export[${EXPORT_DIR}]"
+  bin/rake "rhconsulting:service_dialogs:export[${EXPORT_DIR},keep_spaces=${KEEP_SPACES}]"
   popd
 }
 
 op_service_catalogs () {
+  assert_num_args $# 1
   EXPORT_DIR=$(readlink -v -f "$1")
-
-  if [ ! -d "$EXPORT_DIR" ]
-  then
-    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
-    exit 1
-  fi
+  assert_export_dir_exists "$EXPORT_DIR"
 
   pushd /var/www/miq/vmdb
-  bin/rake "rhconsulting:service_catalogs:export[${EXPORT_DIR}]"
+  bin/rake "rhconsulting:service_catalogs:export[${EXPORT_DIR},keep_spaces=${KEEP_SPACES}]"
   popd
 }
 
 op_roles () {
+  assert_num_args $# 1
   EXPORT_FILE=$(readlink -v -f "$1")
   EXPORT_DIR=$(dirname "$EXPORT_FILE")
-
-  if [ ! -d "$EXPORT_DIR" ]
-  then
-    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
-    exit 1
-  fi
+  assert_export_dir_exists "$EXPORT_DIR"
 
   pushd /var/www/miq/vmdb
-  bin/rake "rhconsulting:roles:export[${EXPORT_FILE}]"
+  bin/rake "rhconsulting:roles:export[${EXPORT_FILE},keep_spaces=${KEEP_SPACES}]"
   popd
 }
 
 op_tags () {
+  assert_num_args $# 1
   EXPORT_FILE=$(readlink -v -f "$1")
   EXPORT_DIR=$(dirname "$EXPORT_FILE")
-
-  if [ ! -d "$EXPORT_DIR" ]
-  then
-    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
-    exit 1
-  fi
+  assert_export_dir_exists "$EXPORT_DIR"
 
   pushd /var/www/miq/vmdb
-  bin/rake "rhconsulting:tags:export[${EXPORT_FILE}]"
+  bin/rake "rhconsulting:tags:export[${EXPORT_FILE},keep_spaces=${KEEP_SPACES}]"
   popd
 }
 
 op_buttons () {
+  assert_num_args $# 1
   EXPORT_FILE=$(readlink -v -f "$1")
   EXPORT_DIR=$(dirname "$EXPORT_FILE")
-
-  if [ ! -d "$EXPORT_DIR" ]
-  then
-    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
-    exit 1
-  fi
+  assert_export_dir_exists "$EXPORT_DIR"
 
   pushd /var/www/miq/vmdb
-  bin/rake "rhconsulting:buttons:export[${EXPORT_FILE}]"
+  bin/rake "rhconsulting:buttons:export[${EXPORT_FILE},keep_spaces=${KEEP_SPACES}]"
   popd
 }
 
 op_customization_templates () {
+  assert_num_args $# 1
   EXPORT_FILE=$(readlink -v -f "$1")
   EXPORT_DIR=$(dirname "$EXPORT_FILE")
-
-  if [ ! -d "$EXPORT_DIR" ]
-  then
-    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
-    exit 1
-  fi
+  assert_export_dir_exists "$EXPORT_DIR"
 
   pushd /var/www/miq/vmdb
-  bin/rake "rhconsulting:customization_templates:export[${EXPORT_FILE}]"
+  bin/rake "rhconsulting:customization_templates:export[${EXPORT_FILE},keep_spaces=${KEEP_SPACES}]"
   popd
 }
 
@@ -201,10 +169,43 @@ contains () {
   return 1  
 }
 
+parse_arguments () {
+  # initialize non-required arguments before the loop in case they are
+  # not present in the command line
+  KEEP_SPACES="false"
+
+  # http://stackoverflow.com/questions/402377/using-getopts-in-bash-shell-script-to-get-long-and-short-command-line-options
+  # http://stackoverflow.com/questions/14786984/best-way-to-parse-cmdline-args-bash
+  while [[ $# -ge 1 ]]
+  do
+    arg="$1"
+    case "$arg" in
+      -s|--keep-spaces)
+        KEEP_SPACES="true"
+        shift # past the argument
+        ;;
+      --)
+        shift # past the argument
+        break # stop parsing arguments
+        ;;
+      *)
+        # unknown option
+        break # stop parsing arguments
+        ;;
+    esac
+  done
+
+  # if there are any required arguments check for them here
+
+  # pass the shifted arguments back to the caller
+  remaining_args="$@"
+}
+
 parse_action () {
   AVAILABLE_PARSERS=`compgen -A function | grep '^op_'`
 
-  op_func="op_$1"
+  obj_type="$1"
+  op_func="op_${obj_type}"
   contains $op_func $AVAILABLE_PARSERS; VALID_OP=$?
 
   if [ $VALID_OP -eq 0 ]
@@ -212,7 +213,9 @@ parse_action () {
     shift
     $op_func "$@"
   else
+    echo "Error: Unknown object type: $obj_type"
     usage
+    exit 1
   fi
 }
 
@@ -220,7 +223,7 @@ usage () {
 progname=`basename $0`
 
   cat << EOF
-Usage: $progname <object_type> <additional_params> <exportdest>
+Usage: $progname [OPTION...] <object_type> <additional_params> <exportdest>
 
 This command exports the specified object type into the <exportdest>,
 which may be a file or directory.
@@ -245,6 +248,11 @@ Available Object Types:
                                    Automate Engine Datastore. <name> MUST
                                    be specified.
 
+Options:
+  -s, --keep-spaces                Export filenames with spaces instead of
+                                   replacing the spaces with underscores.
+                                   (this preserves old behavior)
+
 Report bugs and feature requests to
 https://github.com/rhtconsulting/cfme-rhconsulting-scripts
 
@@ -252,5 +260,6 @@ EOF
 
 }
 
-parse_action "$@"
-
+parse_arguments "$@"
+parse_action "$remaining_args"
+exit 0

--- a/bin/miqexport
+++ b/bin/miqexport
@@ -4,9 +4,9 @@ op_domain () {
   DOMAIN_NAME=$1
   EXPORT_DIR=$2
 
-  if [ ! -d $EXPORT_DIR ]
+  if [ ! -d "$EXPORT_DIR" ]
   then
-    echo "Export directory doesn't exist!"
+    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
     exit 1
   fi
 
@@ -18,9 +18,9 @@ op_domain () {
 op_reports () {
   EXPORT_DIR=$1
 
-  if [ ! -d $EXPORT_DIR ]
+  if [ ! -d "$EXPORT_DIR" ]
   then
-    echo "Export directory doesn't exist!"
+    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
     exit 1
   fi
 
@@ -32,9 +32,9 @@ op_reports () {
 op_widgets () {
   EXPORT_DIR=$1
 
-  if [ ! -d $EXPORT_DIR ]
+  if [ ! -d "$EXPORT_DIR" ]
   then
-    echo "Export directory doesn't exist!"
+    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
     exit 1
   fi
 
@@ -46,9 +46,9 @@ op_widgets () {
 op_alerts () {
   EXPORT_DIR=$1
 
-  if [ ! -d $EXPORT_DIR ]
+  if [ ! -d "$EXPORT_DIR" ]
   then
-    echo "Export directory doesn't exist!"
+    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
     exit 1
   fi
 
@@ -60,9 +60,9 @@ op_alerts () {
 op_alertsets () {
   EXPORT_DIR=$1
 
-  if [ ! -d $EXPORT_DIR ]
+  if [ ! -d "$EXPORT_DIR" ]
   then
-    echo "Export directory doesn't exist!"
+    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
     exit 1
   fi
 
@@ -74,9 +74,9 @@ op_alertsets () {
 op_policies () {
   EXPORT_DIR=$1
 
-  if [ ! -d $EXPORT_DIR ]
+  if [ ! -d "$EXPORT_DIR" ]
   then
-    echo "Export directory doesn't exist!"
+    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
     exit 1
   fi
 
@@ -88,23 +88,23 @@ op_policies () {
 op_provision_dialogs () {
   EXPORT_DIR=$1
 
-  if [ ! -d $EXPORT_DIR ]
+  if [ ! -d "$EXPORT_DIR" ]
   then
-    echo "Export directory doesn't exist!"
+    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
     exit 1
   fi
 
   pushd /var/www/miq/vmdb
-  bin/rake "rhconsulting:provision_dialogs:export[${EXPORT_DIR}]"
+  bin/rake --trace "rhconsulting:provision_dialogs:export[${EXPORT_DIR}]"
   popd
 }
 
 op_service_dialogs () {
   EXPORT_DIR=$1
 
-  if [ ! -d $EXPORT_DIR ]
+  if [ ! -d "$EXPORT_DIR" ]
   then
-    echo "Export directory doesn't exist!"
+    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
     exit 1
   fi
 
@@ -116,9 +116,9 @@ op_service_dialogs () {
 op_service_catalogs () {
   EXPORT_DIR=$1
 
-  if [ ! -d $EXPORT_DIR ]
+  if [ ! -d "$EXPORT_DIR" ]
   then
-    echo "Export directory doesn't exist!"
+    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
     exit 1
   fi
 
@@ -129,10 +129,11 @@ op_service_catalogs () {
 
 op_roles () {
   EXPORT_FILE=$1
+  EXPORT_DIR=$(dirname "$EXPORT_FILE")
 
-  if [ ! -d `dirname $EXPORT_FILE` ]
+  if [ ! -d "$EXPORT_DIR" ]
   then
-    echo "Export directory doesn't exist!"
+    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
     exit 1
   fi
 
@@ -143,10 +144,11 @@ op_roles () {
 
 op_tags () {
   EXPORT_FILE=$1
+  EXPORT_DIR=$(dirname "$EXPORT_FILE")
 
-  if [ ! -d `dirname $EXPORT_FILE` ]
+  if [ ! -d "$EXPORT_DIR" ]
   then
-    echo "Export directory doesn't exist!"
+    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
     exit 1
   fi
 
@@ -157,10 +159,11 @@ op_tags () {
 
 op_buttons () {
   EXPORT_FILE=$1
+  EXPORT_DIR=$(dirname "$EXPORT_FILE")
 
-  if [ ! -d `dirname $EXPORT_FILE` ]
+  if [ ! -d "$EXPORT_DIR" ]
   then
-    echo "Export directory doesn't exist!"
+    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
     exit 1
   fi
 
@@ -171,10 +174,11 @@ op_buttons () {
 
 op_customization_templates () {
   EXPORT_FILE=$1
+  EXPORT_DIR=$(dirname "$EXPORT_FILE")
 
-  if [ ! -d `dirname $EXPORT_FILE` ]
+  if [ ! -d "$EXPORT_DIR" ]
   then
-    echo "Export directory doesn't exist!"
+    echo "Export directory doesn't exist! [${EXPORT_DIR}]"
     exit 1
   fi
 
@@ -206,7 +210,7 @@ parse_action () {
   if [ $VALID_OP -eq 0 ]
   then
     shift
-    $op_func $@
+    $op_func "$@"
   else
     usage
   fi

--- a/bin/miqexport
+++ b/bin/miqexport
@@ -2,7 +2,7 @@
 
 op_domain () {
   DOMAIN_NAME=$1
-  EXPORT_DIR=$(readlink -v -f $2)
+  EXPORT_DIR=$(readlink -v -f "$2")
 
   if [ ! -d "$EXPORT_DIR" ]
   then
@@ -16,7 +16,7 @@ op_domain () {
 }
 
 op_reports () {
-  EXPORT_DIR=$(readlink -v -f $1)
+  EXPORT_DIR=$(readlink -v -f "$1")
 
   if [ ! -d "$EXPORT_DIR" ]
   then
@@ -30,7 +30,7 @@ op_reports () {
 }
 
 op_widgets () {
-  EXPORT_DIR=$(readlink -v -f $1)
+  EXPORT_DIR=$(readlink -v -f "$1")
 
   if [ ! -d "$EXPORT_DIR" ]
   then
@@ -44,7 +44,7 @@ op_widgets () {
 }
 
 op_alerts () {
-  EXPORT_DIR=$(readlink -v -f $1)
+  EXPORT_DIR=$(readlink -v -f "$1")
 
   if [ ! -d "$EXPORT_DIR" ]
   then
@@ -58,7 +58,7 @@ op_alerts () {
 }
 
 op_alertsets () {
-  EXPORT_DIR=$(readlink -v -f $1)
+  EXPORT_DIR=$(readlink -v -f "$1")
 
   if [ ! -d "$EXPORT_DIR" ]
   then
@@ -72,7 +72,7 @@ op_alertsets () {
 }
 
 op_policies () {
-  EXPORT_DIR=$(readlink -v -f $1)
+  EXPORT_DIR=$(readlink -v -f "$1")
 
   if [ ! -d "$EXPORT_DIR" ]
   then
@@ -86,7 +86,7 @@ op_policies () {
 }
 
 op_provision_dialogs () {
-  EXPORT_DIR=$(readlink -v -f $1)
+  EXPORT_DIR=$(readlink -v -f "$1")
 
   if [ ! -d "$EXPORT_DIR" ]
   then
@@ -100,7 +100,7 @@ op_provision_dialogs () {
 }
 
 op_service_dialogs () {
-  EXPORT_DIR=$(readlink -v -f $1)
+  EXPORT_DIR=$(readlink -v -f "$1")
 
   if [ ! -d "$EXPORT_DIR" ]
   then
@@ -114,7 +114,7 @@ op_service_dialogs () {
 }
 
 op_service_catalogs () {
-  EXPORT_DIR=$(readlink -v -f $1)
+  EXPORT_DIR=$(readlink -v -f "$1")
 
   if [ ! -d "$EXPORT_DIR" ]
   then
@@ -128,7 +128,7 @@ op_service_catalogs () {
 }
 
 op_roles () {
-  EXPORT_FILE=$(readlink -v -f $1)
+  EXPORT_FILE=$(readlink -v -f "$1")
   EXPORT_DIR=$(dirname "$EXPORT_FILE")
 
   if [ ! -d "$EXPORT_DIR" ]
@@ -143,7 +143,7 @@ op_roles () {
 }
 
 op_tags () {
-  EXPORT_FILE=$(readlink -v -f $1)
+  EXPORT_FILE=$(readlink -v -f "$1")
   EXPORT_DIR=$(dirname "$EXPORT_FILE")
 
   if [ ! -d "$EXPORT_DIR" ]
@@ -158,7 +158,7 @@ op_tags () {
 }
 
 op_buttons () {
-  EXPORT_FILE=$(readlink -v -f $1)
+  EXPORT_FILE=$(readlink -v -f "$1")
   EXPORT_DIR=$(dirname "$EXPORT_FILE")
 
   if [ ! -d "$EXPORT_DIR" ]
@@ -173,7 +173,7 @@ op_buttons () {
 }
 
 op_customization_templates () {
-  EXPORT_FILE=$(readlink -v -f $1)
+  EXPORT_FILE=$(readlink -v -f "$1")
   EXPORT_DIR=$(dirname "$EXPORT_FILE")
 
   if [ ! -d "$EXPORT_DIR" ]

--- a/bin/miqimport
+++ b/bin/miqimport
@@ -1,28 +1,49 @@
 #!/usr/bin/env bash
 
-op_domain () {
-  DOMAIN_NAME=$1
-  IMPORT_DIR=$(readlink -v -f "$2")
-
-  if [ ! -d "$IMPORT_DIR" ]
+assert_num_args () {
+  num_args_received=$1
+  num_args_expected=$2
+  if [ "$num_args_received" -ne "$num_args_expected" ]
   then
-    echo "Import directory doesn't exist! [${IMPORT_DIR}]"
+    echo "Error: Wrong number of arguments (expected=$num_args_expected received=$num_args_received)"
+    usage
     exit 1
   fi
+}
+
+assert_import_dir_exists () {
+  import_dir=$1
+  if [ ! -d "$import_dir" ]
+  then
+    echo "Import directory doesn't exist! [${import_dir}]"
+    exit 1
+  fi
+}
+
+assert_import_file_or_dir_exists () {
+  import_file_or_dir=$1
+  if [ ! -f "$import_file_or_dir" ] && [ ! -d "$import_file_or_dir" ]
+  then
+    echo "Import file/directory doesn't exist! [${import_file_or_dir}]"
+    exit 1
+  fi
+}
+
+op_domain () {
+  assert_num_args $# 2
+  DOMAIN_NAME=$1
+  IMPORT_DIR=$(readlink -v -f "$2")
+  assert_import_dir_exists "$IMPORT_DIR"
 
   pushd /var/www/miq/vmdb
-  bin/rake "rhconsulting:miq_ae_datastore:import[${DOMAIN_NAME}, ${IMPORT_DIR}]"
+  bin/rake "rhconsulting:miq_ae_datastore:import[${DOMAIN_NAME},${IMPORT_DIR}]"
   popd
 }
 
 op_reports () {
+  assert_num_args $# 1
   IMPORT_DIR=$(readlink -v -f "$1")
-
-  if [ ! -d "$IMPORT_DIR" ]
-  then
-    echo "Import directory doesn't exist! [${IMPORT_DIR}]"
-    exit 1
-  fi
+  assert_import_dir_exists "$IMPORT_DIR"
 
   pushd /var/www/miq/vmdb
   bin/rake "rhconsulting:miq_reports:import[${IMPORT_DIR}]"
@@ -30,13 +51,9 @@ op_reports () {
 }
 
 op_widgets () {
+  assert_num_args $# 1
   IMPORT_DIR=$(readlink -v -f "$1")
-
-  if [ ! -d "$IMPORT_DIR" ]
-  then
-    echo "Import directory doesn't exist! [${IMPORT_DIR}]"
-    exit 1
-  fi
+  assert_import_dir_exists "$IMPORT_DIR"
 
   pushd /var/www/miq/vmdb
   bin/rake "rhconsulting:miq_widgets:import[${IMPORT_DIR}]"
@@ -44,27 +61,19 @@ op_widgets () {
 }
 
 op_alerts () {
+  assert_num_args $# 1  
   IMPORT_FILE_OR_DIR=$(readlink -v -f "$1")
-
-  if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
-  then
-    echo "Import file/directory doesn't exist! [${IMPORT_FILE_OR_DIR}]"
-    exit 1
-  fi
-
+  assert_import_file_or_dir_exists "$IMPORT_FILE_OR_DIR"
+  
   pushd /var/www/miq/vmdb
   bin/rake "rhconsulting:miq_alerts:import[${IMPORT_FILE_OR_DIR}]"
   popd
 }
 
 op_alertsets () {
+  assert_num_args $# 1
   IMPORT_FILE_OR_DIR=$(readlink -v -f "$1")
-
-  if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
-  then
-    echo "Import file/directory doesn't exist! [${IMPORT_FILE_OR_DIR}]"
-    exit 1
-  fi
+  assert_import_file_or_dir_exists "$IMPORT_FILE_OR_DIR"
 
   pushd /var/www/miq/vmdb
   bin/rake "rhconsulting:miq_alertsets:import[${IMPORT_FILE_OR_DIR}]"
@@ -72,13 +81,9 @@ op_alertsets () {
 }
 
 op_policies () {
+  assert_num_args $# 1
   IMPORT_DIR=$(readlink -v -f "$1")
-
-  if [ ! -d "$IMPORT_DIR" ]
-  then
-    echo "Import directory doesn't exist! [${IMPORT_DIR}]"
-    exit 1
-  fi
+  assert_import_dir_exists "$IMPORT_DIR"
 
   pushd /var/www/miq/vmdb
   bin/rake "rhconsulting:miq_policies:import[${IMPORT_DIR}]"
@@ -86,13 +91,9 @@ op_policies () {
 }
 
 op_provision_dialogs () {
+  assert_num_args $# 1
   IMPORT_FILE_OR_DIR=$(readlink -v -f "$1")
-
-  if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
-  then
-    echo "Import file/directory doesn't exist! [${IMPORT_FILE_OR_DIR}]"
-    exit 1
-  fi
+  assert_import_file_or_dir_exists "$IMPORT_FILE_OR_DIR"
 
   pushd /var/www/miq/vmdb
   bin/rake "rhconsulting:provision_dialogs:import[${IMPORT_FILE_OR_DIR}]"
@@ -100,13 +101,9 @@ op_provision_dialogs () {
 }
 
 op_service_dialogs () {
+  assert_num_args $# 1
   IMPORT_FILE_OR_DIR=$(readlink -v -f "$1")
-
-  if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
-  then
-    echo "Import file/directory doesn't exist! [${IMPORT_FILE_OR_DIR}]"
-    exit 1
-  fi
+  assert_import_file_or_dir_exists "$IMPORT_FILE_OR_DIR"
 
   pushd /var/www/miq/vmdb
   bin/rake "rhconsulting:service_dialogs:import[${IMPORT_FILE_OR_DIR}]"
@@ -114,13 +111,9 @@ op_service_dialogs () {
 }
 
 op_service_catalogs () {
+  assert_num_args $# 1
   IMPORT_DIR=$(readlink -v -f "$1")
-
-  if [ ! -d "$IMPORT_DIR" ]
-  then
-    echo "Import directory doesn't exist! [${IMPORT_DIR}]"
-    exit 1
-  fi
+  assert_import_dir_exists "$IMPORT_DIR"
 
   pushd /var/www/miq/vmdb
   bin/rake "rhconsulting:service_catalogs:import[${IMPORT_DIR}]"
@@ -128,13 +121,9 @@ op_service_catalogs () {
 }
 
 op_roles () {
+  assert_num_args $# 1
   IMPORT_FILE_OR_DIR=$(readlink -v -f "$1")
-
-  if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
-  then
-    echo "Import file/directory doesn't exist! [${IMPORT_FILE_OR_DIR}]"
-    exit 1
-  fi
+  assert_import_file_or_dir_exists "$IMPORT_FILE_OR_DIR"
 
   pushd /var/www/miq/vmdb
   bin/rake "rhconsulting:roles:import[${IMPORT_FILE_OR_DIR}]"
@@ -142,13 +131,9 @@ op_roles () {
 }
 
 op_tags () {
+  assert_num_args $# 1
   IMPORT_FILE_OR_DIR=$(readlink -v -f "$1")
-
-  if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
-  then
-    echo "Import file/directory doesn't exist! [${IMPORT_FILE_OR_DIR}]"
-    exit 1
-  fi
+  assert_import_file_or_dir_exists "$IMPORT_FILE_OR_DIR"
 
   pushd /var/www/miq/vmdb
   bin/rake "rhconsulting:tags:import[${IMPORT_FILE_OR_DIR}]"
@@ -156,13 +141,9 @@ op_tags () {
 }
 
 op_buttons () {
+  assert_num_args $# 1
   IMPORT_FILE_OR_DIR=$(readlink -v -f "$1")
-
-  if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
-  then
-    echo "Import file/directory doesn't exist! [${IMPORT_FILE_OR_DIR}]"
-    exit 1
-  fi
+  assert_import_file_or_dir_exists "$IMPORT_FILE_OR_DIR"
 
   pushd /var/www/miq/vmdb
   bin/rake "rhconsulting:buttons:import[${IMPORT_FILE_OR_DIR}]"
@@ -170,13 +151,9 @@ op_buttons () {
 }
 
 op_customization_templates () {
+  assert_num_args $# 1
   IMPORT_FILE_OR_DIR=$(readlink -v -f "$1")
-
-  if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
-  then
-    echo "Import file/directory doesn't exist! [${IMPORT_FILE_OR_DIR}]"
-    exit 1
-  fi
+  assert_import_file_or_dir_exists "$IMPORT_FILE_OR_DIR"
 
   pushd /var/www/miq/vmdb
   bin/rake "rhconsulting:customization_templates:import[${IMPORT_FILE_OR_DIR}]"
@@ -200,7 +177,8 @@ contains () {
 parse_action () {
   AVAILABLE_PARSERS=`compgen -A function | grep '^op_'`
 
-  op_func="op_$1"
+  obj_type="$1"
+  op_func="op_${obj_type}"
   contains $op_func $AVAILABLE_PARSERS; VALID_OP=$?
 
   if [ $VALID_OP -eq 0 ]
@@ -208,7 +186,9 @@ parse_action () {
     shift
     $op_func "$@"
   else
+    echo "Error: Unknown object type: $obj_type"
     usage
+    exit 1
   fi
 }
 
@@ -247,4 +227,4 @@ EOF
 }
 
 parse_action "$@"
-
+exit 0

--- a/bin/miqimport
+++ b/bin/miqimport
@@ -4,9 +4,9 @@ op_domain () {
   DOMAIN_NAME=$1
   IMPORT_DIR=$2
 
-  if [ ! -d $IMPORT_DIR ]
+  if [ ! -d "$IMPORT_DIR" ]
   then
-    echo "Import directory doesn't exist!"
+    echo "Import directory doesn't exist! [${IMPORT_DIR}]"
     exit 1
   fi
 
@@ -18,9 +18,9 @@ op_domain () {
 op_reports () {
   IMPORT_DIR=$1
 
-  if [ ! -d $IMPORT_DIR ]
+  if [ ! -d "$IMPORT_DIR" ]
   then
-    echo "Import directory doesn't exist!"
+    echo "Import directory doesn't exist! [${IMPORT_DIR}]"
     exit 1
   fi
 
@@ -32,9 +32,9 @@ op_reports () {
 op_widgets () {
   IMPORT_DIR=$1
 
-  if [ ! -d $IMPORT_DIR ]
+  if [ ! -d "$IMPORT_DIR" ]
   then
-    echo "Import directory doesn't exist!"
+    echo "Import directory doesn't exist! [${IMPORT_DIR}]"
     exit 1
   fi
 
@@ -44,39 +44,39 @@ op_widgets () {
 }
 
 op_alerts () {
-  IMPORT_DIR=$1
+  IMPORT_FILE_OR_DIR=$1
 
-  if [ ! -d $IMPORT_DIR ]
+  if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
   then
-    echo "Import directory doesn't exist!"
+    echo "Import file/directory doesn't exist! [${IMPORT_FILE_OR_DIR}]"
     exit 1
   fi
 
   pushd /var/www/miq/vmdb
-  bin/rake "rhconsulting:miq_alerts:import[${IMPORT_DIR}]"
+  bin/rake "rhconsulting:miq_alerts:import[${IMPORT_FILE_OR_DIR}]"
   popd
 }
 
 op_alertsets () {
-  IMPORT_DIR=$1
+  IMPORT_FILE_OR_DIR=$1
 
-  if [ ! -d $IMPORT_DIR ]
+  if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
   then
-    echo "Import directory doesn't exist!"
+    echo "Import file/directory doesn't exist! [${IMPORT_FILE_OR_DIR}]"
     exit 1
   fi
 
   pushd /var/www/miq/vmdb
-  bin/rake "rhconsulting:miq_alertsets:import[${IMPORT_DIR}]"
+  bin/rake "rhconsulting:miq_alertsets:import[${IMPORT_FILE_OR_DIR}]"
   popd
 }
 
 op_policies () {
   IMPORT_DIR=$1
 
-  if [ ! -d $IMPORT_DIR ]
+  if [ ! -d "$IMPORT_DIR" ]
   then
-    echo "Import directory doesn't exist!"
+    echo "Import directory doesn't exist! [${IMPORT_DIR}]"
     exit 1
   fi
 
@@ -86,39 +86,39 @@ op_policies () {
 }
 
 op_provision_dialogs () {
-  IMPORT_DIR=$1
+  IMPORT_FILE_OR_DIR=$1
 
-  if [ ! -d $IMPORT_DIR ]
+  if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
   then
-    echo "Import directory doesn't exist!"
+    echo "Import file/directory doesn't exist! [${IMPORT_FILE_OR_DIR}]"
     exit 1
   fi
 
   pushd /var/www/miq/vmdb
-  bin/rake "rhconsulting:provision_dialogs:import[${IMPORT_DIR}]"
+  bin/rake "rhconsulting:provision_dialogs:import[${IMPORT_FILE_OR_DIR}]"
   popd
 }
 
 op_service_dialogs () {
-  IMPORT_DIR=$1
+  IMPORT_FILE_OR_DIR=$1
 
-  if [ ! -d $IMPORT_DIR ]
+  if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
   then
-    echo "Import directory doesn't exist!"
+    echo "Import file/directory doesn't exist! [${IMPORT_FILE_OR_DIR}]"
     exit 1
   fi
 
   pushd /var/www/miq/vmdb
-  bin/rake "rhconsulting:service_dialogs:import[${IMPORT_DIR}]"
+  bin/rake "rhconsulting:service_dialogs:import[${IMPORT_FILE_OR_DIR}]"
   popd
 }
 
 op_service_catalogs () {
   IMPORT_DIR=$1
 
-  if [ ! -d $IMPORT_DIR ]
+  if [ ! -d "$IMPORT_DIR" ]
   then
-    echo "Import directory doesn't exist!"
+    echo "Import directory doesn't exist! [${IMPORT_DIR}]"
     exit 1
   fi
 
@@ -128,65 +128,65 @@ op_service_catalogs () {
 }
 
 op_roles () {
-  IMPORT_FILE=$1
+  IMPORT_FILE_OR_DIR=$1
 
-  if [ ! -f $IMPORT_FILE ]
+  if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
   then
-    echo "Import file doesn't exist!"
+    echo "Import file/directory doesn't exist! [${IMPORT_FILE_OR_DIR}]"
     exit 1
   fi
 
   pushd /var/www/miq/vmdb
-  bin/rake "rhconsulting:roles:import[${IMPORT_FILE}]"
+  bin/rake "rhconsulting:roles:import[${IMPORT_FILE_OR_DIR}]"
   popd
 }
 
 op_tags () {
-  IMPORT_FILE=$1
+  IMPORT_FILE_OR_DIR=$1
 
-  if [ ! -f $IMPORT_FILE ]
+  if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
   then
-    echo "Import file doesn't exist!"
+    echo "Import file/directory doesn't exist! [${IMPORT_FILE_OR_DIR}]"
     exit 1
   fi
 
   pushd /var/www/miq/vmdb
-  bin/rake "rhconsulting:tags:import[${IMPORT_FILE}]"
+  bin/rake "rhconsulting:tags:import[${IMPORT_FILE_OR_DIR}]"
   popd
 }
 
 op_buttons () {
-  IMPORT_FILE=$1
+  IMPORT_FILE_OR_DIR=$1
 
-  if [ ! -f $IMPORT_FILE ]
+  if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
   then
-    echo "Import file doesn't exist!"
+    echo "Import file/directory doesn't exist! [${IMPORT_FILE_OR_DIR}]"
     exit 1
   fi
 
   pushd /var/www/miq/vmdb
-  bin/rake "rhconsulting:buttons:import[${IMPORT_FILE}]"
+  bin/rake "rhconsulting:buttons:import[${IMPORT_FILE_OR_DIR}]"
   popd
 }
 
 op_customization_templates () {
-  IMPORT_FILE=$1
+  IMPORT_FILE_OR_DIR=$1
 
-  if [ ! -f $IMPORT_FILE ]
+  if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
   then
-    echo "Import file doesn't exist!"
+    echo "Import file/directory doesn't exist! [${IMPORT_FILE_OR_DIR}]"
     exit 1
   fi
 
   pushd /var/www/miq/vmdb
-  bin/rake "rhconsulting:customization_templates:import[${IMPORT_FILE}]"
+  bin/rake "rhconsulting:customization_templates:import[${IMPORT_FILE_OR_DIR}]"
   popd
 }
 
 contains () {
   SEARCH_TERM=$1
   shift
-  LIST=$@
+  LIST="$@"
 
   for element in $LIST; do
     if [[ "$SEARCH_TERM" == "$element" ]]; then
@@ -206,7 +206,7 @@ parse_action () {
   if [ $VALID_OP -eq 0 ]
   then
     shift
-    $op_func $@
+    $op_func "$@"
   else
     usage
   fi

--- a/bin/miqimport
+++ b/bin/miqimport
@@ -35,8 +35,28 @@ op_domain () {
   IMPORT_DIR=$(readlink -v -f "$2")
   assert_import_dir_exists "$IMPORT_DIR"
 
+  DOMAIN_OPTIONS=""
+  if [ ! -z $OVERWRITE ]
+  then
+    DOMAIN_OPTIONS="${DOMAIN_OPTIONS}overwrite=${OVERWRITE};"
+  fi
+  if [ ! -z $ENABLED ]
+  then
+    DOMAIN_OPTIONS="${DOMAIN_OPTIONS}enabled=${ENABLED};"
+  fi
+  if [ ! -z $TENANT_NAME ]
+  then
+    DOMAIN_OPTIONS="${DOMAIN_OPTIONS}tenant_name=${TENANT_NAME};"
+  fi
+  if [ ! -z $TENANT_ID ]
+  then
+    DOMAIN_OPTIONS="${DOMAIN_OPTIONS}tenant_id=${TENANT_ID};"
+  fi
+
+  echo "DOMAIN_OPTIONS=${DOMAIN_OPTIONS}"
+  
   pushd /var/www/miq/vmdb
-  bin/rake "rhconsulting:miq_ae_datastore:import[${DOMAIN_NAME},${IMPORT_DIR}]"
+  bin/rake "rhconsulting:miq_ae_datastore:import_with_options[${DOMAIN_NAME},${IMPORT_DIR},${DOMAIN_OPTIONS}]"
   popd
 }
 
@@ -174,6 +194,72 @@ contains () {
   return 1  
 }
 
+
+parse_arguments () {
+  # initialize non-required arguments before the loop in case they are
+  # not present in the command line
+  OVERWRITE="false"
+  ENABLED="true"
+  TENANT_NAME=""
+  TENANT_ID=""
+
+  # http://stackoverflow.com/questions/402377/using-getopts-in-bash-shell-script-to-get-long-and-short-command-line-options
+  # http://stackoverflow.com/questions/14786984/best-way-to-parse-cmdline-args-bash
+  while [[ $# -ge 1 ]]
+  do
+    arg="$1"
+    case "$arg" in
+      --overwrite)
+        OVERWRITE="true"
+        shift # past the argument
+        ;;
+      --no-overwrite)
+        OVERWRITE="false"
+        shift # past the argument
+        ;;
+      --enabled)
+        ENABLED="true"
+        shift # past the argument
+        ;;
+      --disabled)
+        ENABLED="false"
+        shift # past the argument
+        ;;
+      --tenant-name)
+        TENANT_NAME="$2"
+        shift # past the argument
+        shift # past the value
+        ;;
+      --tenant-name=*)
+        TENANT_NAME="${arg#*=}"
+        shift # past the argument=value
+        ;;
+      --tenant-id)
+        TENANT_ID="$2"
+        shift # past the argument
+        shift # past the value
+        ;;
+      --tenant-id=*)
+        TENANT_ID="${arg#*=}"
+        shift # past the argument=value
+        ;;
+      --)
+        shift # past the argument
+        break # stop parsing arguments
+        ;;
+      *)
+        # unknown option
+        break # stop parsing arguments
+        ;;
+    esac
+  done
+
+  # if there are any required arguments check for them here
+
+  # pass the shifted arguments back to the caller
+  remaining_args="$@"
+}
+
 parse_action () {
   AVAILABLE_PARSERS=`compgen -A function | grep '^op_'`
 
@@ -219,6 +305,35 @@ Available Object Types:
                                    <importsource> directory. <name> MUST
                                    be specified.
 
+Options:
+  --overwrite                      Overwites the imported domain if it
+                                   already exists in the database.
+                                   Only used for "domain" object type.
+                                   (Default = overwrite)
+
+  --no-overwrite                   Do NOT overwite the domain if it
+                                   already exists in the database.
+                                   Only used for "domain" object type.
+                                   (Default = overwrite)
+
+  --enabled                        Enables the domain after it is imported.
+                                   Only used for "domain" object type.
+                                   (Default = enabled)
+
+  --disabled                       Disables the domain after it is imported.
+                                   Only used for "domain" object type.
+                                   (Default = enabled)
+
+  --tenant-name=NAME               Name of the Tenant for the domain after it is
+                                   imported.
+                                   Only used for "domain" object type.
+                                   (Default = "")
+
+  --tenant-id=ID                   ID of the Tenant for the domain after it is
+                                   imported.
+                                   Only used for "domain" object type.
+                                   (Default = "")
+
 Report bugs and feature requests to
 https://github.com/rhtconsulting/cfme-rhconsulting-scripts
 
@@ -226,5 +341,6 @@ EOF
 
 }
 
-parse_action "$@"
+parse_arguments "$@"
+parse_action "$remaining_args"
 exit 0

--- a/bin/miqimport
+++ b/bin/miqimport
@@ -2,7 +2,7 @@
 
 op_domain () {
   DOMAIN_NAME=$1
-  IMPORT_DIR=$(readlink -v -f $2)
+  IMPORT_DIR=$(readlink -v -f "$2")
 
   if [ ! -d "$IMPORT_DIR" ]
   then
@@ -16,7 +16,7 @@ op_domain () {
 }
 
 op_reports () {
-  IMPORT_DIR=$(readlink -v -f $1)
+  IMPORT_DIR=$(readlink -v -f "$1")
 
   if [ ! -d "$IMPORT_DIR" ]
   then
@@ -30,7 +30,7 @@ op_reports () {
 }
 
 op_widgets () {
-  IMPORT_DIR=$(readlink -v -f $1)
+  IMPORT_DIR=$(readlink -v -f "$1")
 
   if [ ! -d "$IMPORT_DIR" ]
   then
@@ -44,7 +44,7 @@ op_widgets () {
 }
 
 op_alerts () {
-  IMPORT_FILE_OR_DIR=$(readlink -v -f $1)
+  IMPORT_FILE_OR_DIR=$(readlink -v -f "$1")
 
   if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
   then
@@ -58,7 +58,7 @@ op_alerts () {
 }
 
 op_alertsets () {
-  IMPORT_FILE_OR_DIR=$(readlink -v -f $1)
+  IMPORT_FILE_OR_DIR=$(readlink -v -f "$1")
 
   if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
   then
@@ -72,7 +72,7 @@ op_alertsets () {
 }
 
 op_policies () {
-  IMPORT_DIR=$(readlink -v -f $1)
+  IMPORT_DIR=$(readlink -v -f "$1")
 
   if [ ! -d "$IMPORT_DIR" ]
   then
@@ -86,7 +86,7 @@ op_policies () {
 }
 
 op_provision_dialogs () {
-  IMPORT_FILE_OR_DIR=$(readlink -v -f $1)
+  IMPORT_FILE_OR_DIR=$(readlink -v -f "$1")
 
   if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
   then
@@ -100,7 +100,7 @@ op_provision_dialogs () {
 }
 
 op_service_dialogs () {
-  IMPORT_FILE_OR_DIR=$(readlink -v -f $1)
+  IMPORT_FILE_OR_DIR=$(readlink -v -f "$1")
 
   if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
   then
@@ -114,7 +114,7 @@ op_service_dialogs () {
 }
 
 op_service_catalogs () {
-  IMPORT_DIR=$(readlink -v -f $1)
+  IMPORT_DIR=$(readlink -v -f "$1")
 
   if [ ! -d "$IMPORT_DIR" ]
   then
@@ -128,7 +128,7 @@ op_service_catalogs () {
 }
 
 op_roles () {
-  IMPORT_FILE_OR_DIR=$(readlink -v -f $1)
+  IMPORT_FILE_OR_DIR=$(readlink -v -f "$1")
 
   if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
   then
@@ -142,7 +142,7 @@ op_roles () {
 }
 
 op_tags () {
-  IMPORT_FILE_OR_DIR=$(readlink -v -f $1)
+  IMPORT_FILE_OR_DIR=$(readlink -v -f "$1")
 
   if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
   then
@@ -156,7 +156,7 @@ op_tags () {
 }
 
 op_buttons () {
-  IMPORT_FILE_OR_DIR=$(readlink -v -f $1)
+  IMPORT_FILE_OR_DIR=$(readlink -v -f "$1")
 
   if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
   then
@@ -170,7 +170,7 @@ op_buttons () {
 }
 
 op_customization_templates () {
-  IMPORT_FILE_OR_DIR=$(readlink -v -f $1)
+  IMPORT_FILE_OR_DIR=$(readlink -v -f "$1")
 
   if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
   then

--- a/bin/miqimport
+++ b/bin/miqimport
@@ -2,7 +2,7 @@
 
 op_domain () {
   DOMAIN_NAME=$1
-  IMPORT_DIR=$2
+  IMPORT_DIR=$(readlink -v -f $2)
 
   if [ ! -d "$IMPORT_DIR" ]
   then
@@ -16,7 +16,7 @@ op_domain () {
 }
 
 op_reports () {
-  IMPORT_DIR=$1
+  IMPORT_DIR=$(readlink -v -f $1)
 
   if [ ! -d "$IMPORT_DIR" ]
   then
@@ -30,7 +30,7 @@ op_reports () {
 }
 
 op_widgets () {
-  IMPORT_DIR=$1
+  IMPORT_DIR=$(readlink -v -f $1)
 
   if [ ! -d "$IMPORT_DIR" ]
   then
@@ -44,7 +44,7 @@ op_widgets () {
 }
 
 op_alerts () {
-  IMPORT_FILE_OR_DIR=$1
+  IMPORT_FILE_OR_DIR=$(readlink -v -f $1)
 
   if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
   then
@@ -58,7 +58,7 @@ op_alerts () {
 }
 
 op_alertsets () {
-  IMPORT_FILE_OR_DIR=$1
+  IMPORT_FILE_OR_DIR=$(readlink -v -f $1)
 
   if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
   then
@@ -72,7 +72,7 @@ op_alertsets () {
 }
 
 op_policies () {
-  IMPORT_DIR=$1
+  IMPORT_DIR=$(readlink -v -f $1)
 
   if [ ! -d "$IMPORT_DIR" ]
   then
@@ -86,7 +86,7 @@ op_policies () {
 }
 
 op_provision_dialogs () {
-  IMPORT_FILE_OR_DIR=$1
+  IMPORT_FILE_OR_DIR=$(readlink -v -f $1)
 
   if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
   then
@@ -100,7 +100,7 @@ op_provision_dialogs () {
 }
 
 op_service_dialogs () {
-  IMPORT_FILE_OR_DIR=$1
+  IMPORT_FILE_OR_DIR=$(readlink -v -f $1)
 
   if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
   then
@@ -114,7 +114,7 @@ op_service_dialogs () {
 }
 
 op_service_catalogs () {
-  IMPORT_DIR=$1
+  IMPORT_DIR=$(readlink -v -f $1)
 
   if [ ! -d "$IMPORT_DIR" ]
   then
@@ -128,7 +128,7 @@ op_service_catalogs () {
 }
 
 op_roles () {
-  IMPORT_FILE_OR_DIR=$1
+  IMPORT_FILE_OR_DIR=$(readlink -v -f $1)
 
   if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
   then
@@ -142,7 +142,7 @@ op_roles () {
 }
 
 op_tags () {
-  IMPORT_FILE_OR_DIR=$1
+  IMPORT_FILE_OR_DIR=$(readlink -v -f $1)
 
   if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
   then
@@ -156,7 +156,7 @@ op_tags () {
 }
 
 op_buttons () {
-  IMPORT_FILE_OR_DIR=$1
+  IMPORT_FILE_OR_DIR=$(readlink -v -f $1)
 
   if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
   then
@@ -170,7 +170,7 @@ op_buttons () {
 }
 
 op_customization_templates () {
-  IMPORT_FILE_OR_DIR=$1
+  IMPORT_FILE_OR_DIR=$(readlink -v -f $1)
 
   if [ ! -f "$IMPORT_FILE_OR_DIR" ] && [ ! -d "$IMPORT_FILE_OR_DIR" ]
   then

--- a/cfme-rhconsulting-scripts.spec
+++ b/cfme-rhconsulting-scripts.spec
@@ -1,5 +1,5 @@
 Name:      cfme-rhconsulting-scripts
-Version:   0.8
+Version:   0.9
 Release:   1
 Summary:   Red Hat Consulting Scripts for CloudForms
 

--- a/cfme-rhconsulting-scripts.spec
+++ b/cfme-rhconsulting-scripts.spec
@@ -23,6 +23,7 @@ mkdir -p "%{buildroot}/var/www/miq/vmdb/lib/tasks"
 mkdir -p "%{buildroot}/usr/bin"
 cd %{_builddir}/%{name}
 install --backup --mode=0644 -t "%{buildroot}/var/www/miq/vmdb/lib/tasks/$f" *.rake
+install --backup --mode=0644 -t "%{buildroot}/var/www/miq/vmdb/lib/tasks/$f" *.rb
 install --backup --mode=0755 -t "%{buildroot}/usr/bin" bin/miqexport
 install --backup --mode=0755 -t "%{buildroot}/usr/bin" bin/miqimport
 install --backup --mode=0755 -t "%{buildroot}/usr/bin" bin/export-miqdomain
@@ -41,6 +42,8 @@ install --backup --mode=0755 -t "%{buildroot}/usr/bin" bin/import-miqdomain
 /var/www/miq/vmdb/lib/tasks/rhconsulting_widgets.rake
 /var/www/miq/vmdb/lib/tasks/rhconsulting_policies.rake
 /var/www/miq/vmdb/lib/tasks/rhconsulting_alerts.rake
+/var/www/miq/vmdb/lib/tasks/rhconsulting_illegal_chars.rb
+/var/www/miq/vmdb/lib/tasks/rhconsulting_options.rb
 /usr/bin/miqexport
 /usr/bin/miqimport
 /usr/bin/export-miqdomain
@@ -49,6 +52,17 @@ install --backup --mode=0755 -t "%{buildroot}/usr/bin" bin/import-miqdomain
 %post
 
 %changelog
+* Wed Oct 19 2016 Nick Maludy <nmaludy@gmail.com> 0.9
+- Added support for importing/export individual files
+- Added support for importing/exporting filenames and directories with spaces
+- Added support for importing/exporting relative paths
+- Added support for importing/exporting paths with symlinks
+- Changed export file naming behavior to replace spaces with _
+  * Note: to preserve old behavior and keep spaces the command line option
+    --keep-spaces was added
+- Added several new command line options to expose various underlying
+  functionality in miqimport
+
 * Mon Aug 15 2016 Brant Evans <bevans@redhat.com> 0.8
 - Added export/import for provisioning dialogs
 

--- a/rhconsulting_alerts.rake
+++ b/rhconsulting_alerts.rake
@@ -52,9 +52,9 @@ class MiqAlertsImportExport
   def export_alerts(export_dir)
     MiqAlert.order(:id).all.each do |a|
       # Replace characters in the description that are not allowed in filenames
-      fname = a.description.gsub('/', '_')
-      fname = fname.gsub('|', '_')
-
+      # Illegal characters: '/', '|', ' '
+      # Replaced with: '_'
+      fname = a.description.gsub(%r{[/| ]}, '_')
       File.write("#{export_dir}/#{fname}.yaml", a.export_to_yaml)
     end
   end
@@ -64,9 +64,9 @@ class MiqAlertsImportExport
       puts("Exporting Alert Set: #{a.description}")
 
       # Replace characters in the description that are not allowed in filenames
-      fname = a.description.gsub('/', '_')
-      fname = fname.gsub('|', '_')
-
+      # Illegal characters: '/', '|', ' '
+      # Replaced with: '_'
+      fname = a.description.gsub(%r{[/| ]}, '_')
       File.write("#{export_dir}/#{fname}.yaml", a.export_to_yaml)
     end
   end

--- a/rhconsulting_buttons.rake
+++ b/rhconsulting_buttons.rake
@@ -42,7 +42,11 @@ class ButtonsImportExport
       File.write(filename, {:custom_buttons_sets => custom_buttons_sets_hash}.to_yaml)
     elsif file_type == 'directory'
       custom_buttons_sets_hash.each do |cbs|
-        fname = "#{filename}/#{cbs["name"].gsub("|", "_")}.yaml"
+        # Replace characters in the name that are not allowed in filenames
+        # Illegal characters: '/', '|', ' '
+        # Replaced with: '_'
+        name = "#{cbs["name"]}".gsub(%r{[/| ]}, '_')
+        fname = "#{filename}/#{name}.yaml"
         File.write(fname, {:custom_buttons_sets => [cbs]}.to_yaml)
       end
     else

--- a/rhconsulting_buttons.rake
+++ b/rhconsulting_buttons.rake
@@ -1,3 +1,6 @@
+require_relative 'rhconsulting_illegal_chars'
+require_relative 'rhconsulting_options'
+
 class ButtonsImportExport
 
   def import(filename)
@@ -13,7 +16,7 @@ class ButtonsImportExport
     end
   end
 
-  def export(filename)
+  def export(filename, options = {})
     raise "Must supply filename or directory" if filename.blank?
     begin
       file_type = File.ftype(filename)
@@ -43,9 +46,7 @@ class ButtonsImportExport
     elsif file_type == 'directory'
       custom_buttons_sets_hash.each do |cbs|
         # Replace characters in the name that are not allowed in filenames
-        # Illegal characters: '/', '|', ' '
-        # Replaced with: '_'
-        name = "#{cbs["name"]}".gsub(%r{[/| ]}, '_')
+        name = MiqIllegalChars.replace("#{cbs["name"]}", options)
         fname = "#{filename}/#{name}.yaml"
         File.write(fname, {:custom_buttons_sets => [cbs]}.to_yaml)
       end
@@ -268,7 +269,8 @@ namespace :rhconsulting do
 
     desc 'Exports all dialogs to a YAML file'
     task :export, [:filename] => [:environment] do |_, arguments|
-      ButtonsImportExport.new.export(arguments[:filename])
+      options = RhconsultingOptions.parse_options(arguments.extras)
+      ButtonsImportExport.new.export(arguments[:filename], options)
     end
 
   end

--- a/rhconsulting_customization_templates.rake
+++ b/rhconsulting_customization_templates.rake
@@ -1,4 +1,6 @@
 # Author: George Goh <george.goh@redhat.com>
+require_relative 'rhconsulting_illegal_chars'
+require_relative 'rhconsulting_options'
 
 class CustomizationTemplateImportExport
   class ParsedNonDialogYamlError < StandardError; end
@@ -18,7 +20,7 @@ class CustomizationTemplateImportExport
     end
   end
 
-  def export(filename)
+  def export(filename, options = {})
     raise "Must supply filename or directory" if filename.blank?
     begin
       file_type = File.ftype(filename)
@@ -37,9 +39,7 @@ class CustomizationTemplateImportExport
         name = "#{template_hash["name"]}"
 
         # Replace invalid filename characters
-        # Illegal characters: '/', '|', ' '
-        # Replaced with: '_'
-        name = name.gsub(%r{[/| ]}, '_')
+        name = MiqIllegalChars.replace(name, options)
         fname = "#{filename}/#{name}.yaml"
 
         File.write(fname, [template_hash].to_yaml)
@@ -95,7 +95,8 @@ namespace :rhconsulting do
 
     desc 'Exports all customization templates to a YAML file or directory'
     task :export, [:filename] => [:environment] do |_, arguments|
-      CustomizationTemplateImportExport.new.export(arguments[:filename])
+      options = RhconsultingOptions.parse_options(arguments.extras)
+      CustomizationTemplateImportExport.new.export(arguments[:filename], options)
     end
 
   end

--- a/rhconsulting_customization_templates.rake
+++ b/rhconsulting_customization_templates.rake
@@ -37,8 +37,9 @@ class CustomizationTemplateImportExport
         name = "#{template_hash["name"]}"
 
         # Replace invalid filename characters
-        name = name.gsub('/', '_')
-        name = name.gsub('|', '_')
+        # Illegal characters: '/', '|', ' '
+        # Replaced with: '_'
+        name = name.gsub(%r{[/| ]}, '_')
         fname = "#{filename}/#{name}.yaml"
 
         File.write(fname, [template_hash].to_yaml)

--- a/rhconsulting_illegal_chars.rb
+++ b/rhconsulting_illegal_chars.rb
@@ -1,0 +1,32 @@
+# @class MiqIllegalChars
+# @brief Common place for illegal character replacement regexes and functions.
+# Previously regexes for illegal character replacement were spread throughout
+# the code. This class centralized the regexes and replacement functions so
+# when these need to change then it can be done in one place.
+class MiqIllegalChars
+
+  # Illegal characters: '/', '|'
+  @@regex_keep_spaces   = %r{[/|]}
+  
+  # Illegal characters: '/', '|', ' '
+  @@regex_remove_spaces = %r{[/| ]}
+
+  # Replacement character
+  @@replacement         = '_'
+
+  # Replace characters in \p str that are not allowed in filenames.
+  # Illegal characters are matched from the regexes @@regex_remove_spaces
+  # (if \p keep_spaces = false ) @@regex_keep_spaces (if \p keep_spaces = true).
+  # Illegal characters are replaced with @@replacement.
+  # @param [String] str string to replace
+  # @param [Hash] options If options[:keep_spaces] == true, then keep spaces in
+  # \p str , otherwise replace spaces. (default = false, replace spaces)
+  def self.replace(str, options = {})
+    if options.has_key?(:keep_spaces) && options[:keep_spaces] == true
+      return str.gsub(@@regex_keep_spaces, @@replacement)
+    else
+      return str.gsub(@@regex_remove_spaces, @@replacement)
+    end
+  end
+  
+end # class MiqIllegalChars

--- a/rhconsulting_miq_ae_datastore.rake
+++ b/rhconsulting_miq_ae_datastore.rake
@@ -7,6 +7,13 @@ class MiqAeDatastoreImportExport
     raise "Must supply domain name" if domain_name.blank?
     raise "Must supply import source directory" if options['import_dir'].blank?
     importer = MiqAeYamlImportFs.new(domain_name, options)
+    # Overwrite doesn't work in ManageIQ/CloudForms < 4.1 (cfme version 5.6)
+    # In these versions we have to manually delete the domain and then import.
+    # This is exactly what happens in newer versions where overwrite is fixed.
+    if options['overwrite'] && Vmdb::Appliance.VERSION < "5.6"
+      domain_obj = MiqAeDomain.find_by_name(domain_name)
+      domain_obj.destroy
+    end
     importer.import
   end
 

--- a/rhconsulting_options.rb
+++ b/rhconsulting_options.rb
@@ -1,0 +1,100 @@
+# @class RhconsultingOptions
+# @brief Simple class to parse options passed in to a rake task.
+class RhconsultingOptions
+
+  # Tries to parse a string into a more meaningful object using
+  # trial and error. The parsing priorities are:
+  #  - Integer
+  #  - Float
+  #  - Boolean
+  #
+  # If all of those fail, then the original string is returned.
+  # @param [String] str the string to try and parse
+  # @return A parsed object if we were able to parse something more meaningful,
+  # or \p str if we weren't.
+  def self.try_parse(str)
+    # try parse into an Integer (exception is raised if this fails)
+    begin
+      return Integer(str)
+    rescue
+    end
+
+    # try parse into a float (exception is raised if this fails)
+    begin
+      return Float(str)
+    rescue
+    end
+
+    # try parse into a boolean (case insensitive)
+    if str =~ /^true$/i
+      return true
+    elsif str =~ /^false$/i
+      return false
+    end
+
+    # otherwise it's a string
+    return str
+  end
+
+  # Parses the options in \p options_str and stores them in a hash.
+  # The options within \p options_str are assumed to be option and value
+  # pairs. The option and value are separated by a '='
+  #   Example: "ride_skateboard=true"
+  #
+  # Each option/value pair is separated by a ';' from the next.
+  #  Example: "ride_skateboard=true;shoe_size=11;hat_color=red"
+  #
+  # When the option/value pairs are parsed each option string is converted
+  # into a symbol and used as the key in the options hash that is returned.
+  # The value in the pair is parsed using the try_parse() function.
+  #
+  # @param [String] options_str String of options.
+  # @return Hash containing option/value pairs where options are converted
+  # to symbols and used as the keys for the hash. Values are parsed using
+  # try_parse() and assigned to the corresponding option key in the hash.
+  def self.parse_options_str(options_str)
+    options = {}
+    
+    # parse options that are separated by ;
+    options_str.split(';').each do |passed_option|
+      # break apart the option and the value using = as delimiter
+      option, value = passed_option.split('=')
+      
+      # convert option to symbol and try to parse value into a
+      # meaningful data type, otherwise just the value string is returned
+      options[option.to_sym] = try_parse(value)
+    end
+    return options
+  end
+
+  # Parses an array of options strings into a single Hash.
+  # This simply calls parse_options() for each element in \p options_array
+  # and merges all hashes into one.
+  # @param [Array<String>] options_array Array of strings, each string
+  # containing options.
+  # @return A single hash containing all options parsed from the option
+  # strings in \p options_array
+  def self.parse_options_array(options_array)
+    options = {}
+    options_array.flatten.each do |options_str|
+      parsed_options = parse_options(options_str)
+      options.merge!(parsed_options)
+    end
+    return options
+  end
+
+  # Parses the options into a hash.
+  # @param [mixed] options 
+  def self.parse_options(options)
+    # If the option strings are in an array, use the array parsing
+    # method
+    case options
+    when Array
+      return parse_options_array(options)
+    end
+    
+    # otherwise assume string
+    return parse_options_str(options)
+  end
+  
+end # class RhconsultingOptions

--- a/rhconsulting_policies.rake
+++ b/rhconsulting_policies.rake
@@ -29,7 +29,12 @@ private
     MiqPolicy.all.each do |p|
       puts("Exporting Policy: #{p.description}")
 
-      File.write("#{export_dir}/Policy_#{p.description.gsub('/', '_')}.yaml", p.export_to_yaml)
+      # Replace invalid filename characters
+      # Illegal characters: '/', '|', ' '
+      # Replaced with: '_'
+      pname = p.description.gsub(%r{[/| ]}, '_')
+      fname = "Policy_#{pname}.yaml"
+      File.write("#{export_dir}/#{fname}", p.export_to_yaml)
     end
   end
 
@@ -37,7 +42,12 @@ private
     MiqPolicySet.all.each do |p|
       puts("Exporting Policy Profile: #{p.description}")
 
-      File.write("#{export_dir}/Profile_#{p.description.gsub('/', '_')}.yaml", p.export_to_yaml)
+      # Replace invalid filename characters
+      # Illegal characters: '/', '|', ' '
+      # Replaced with: '_'
+      pname = p.description.gsub(%r{[/| ]}, '_')
+      fname = "Profile_#{pname}.yaml"
+      File.write("#{export_dir}/#{fname}", p.export_to_yaml)
     end
   end
 

--- a/rhconsulting_policies.rake
+++ b/rhconsulting_policies.rake
@@ -1,16 +1,18 @@
 # Author: Brant Evans <bevans@redhat.com>
+require_relative 'rhconsulting_illegal_chars'
+require_relative 'rhconsulting_options'
 
 class MiqPoliciesImportExport
   class ParsedNonDialogYamlError < StandardError; end
 
-  def export(export_dir)
+  def export(export_dir, options = {})
     raise "Must supply export dir" if export_dir.blank?
 
     # Export the Policy Profiles
-    export_profiles(export_dir)
+    export_profiles(export_dir, options)
 
     # Export the Policies
-    export_policies(export_dir)
+    export_policies(export_dir, options)
   end
 
   def import(import_dir)
@@ -25,27 +27,23 @@ class MiqPoliciesImportExport
 
 private
 
-  def export_policies(export_dir)
+  def export_policies(export_dir, options)
     MiqPolicy.all.each do |p|
       puts("Exporting Policy: #{p.description}")
 
       # Replace invalid filename characters
-      # Illegal characters: '/', '|', ' '
-      # Replaced with: '_'
-      pname = p.description.gsub(%r{[/| ]}, '_')
+      pname = MiqIllegalChars.replace(p.description, options)
       fname = "Policy_#{pname}.yaml"
       File.write("#{export_dir}/#{fname}", p.export_to_yaml)
     end
   end
 
-  def export_profiles(export_dir)
+  def export_profiles(export_dir, options)
     MiqPolicySet.all.each do |p|
       puts("Exporting Policy Profile: #{p.description}")
 
       # Replace invalid filename characters
-      # Illegal characters: '/', '|', ' '
-      # Replaced with: '_'
-      pname = p.description.gsub(%r{[/| ]}, '_')
+      pname = MiqIllegalChars.replace(p.description, options)
       fname = "Profile_#{pname}.yaml"
       File.write("#{export_dir}/#{fname}", p.export_to_yaml)
     end
@@ -91,7 +89,8 @@ namespace :rhconsulting do
 
     desc 'Imports all policies from individual YAML files'
     task :import, [:filedir] => [:environment] do |_, arguments|
-      MiqPoliciesImportExport.new.import(arguments[:filedir])
+      options = RhconsultingOptions.parse_options(arguments.extras)
+      MiqPoliciesImportExport.new.import(arguments[:filedir], options)
     end
 
   end

--- a/rhconsulting_provision_dialogs.rake
+++ b/rhconsulting_provision_dialogs.rake
@@ -1,10 +1,12 @@
 # Heavily based on a rails script written by Dustin Scott <dscott@redhat.com>
 # Author: Brant Evans <bevans@redhat.com>
+require_relative 'rhconsulting_illegal_chars'
+require_relative 'rhconsulting_options'
 
 class ProvisionDialogImportExport
   class ParsedNonDialogYamlError < StandardError; end
 
-  def export(filedir)
+  def export(filedir, options = {})
     # Do some basic checks
     raise "Must supply export directory" if filedir.blank?
     raise "#{filedir} does not exist" if ! File.exist?(filedir)
@@ -17,10 +19,7 @@ class ProvisionDialogImportExport
     # Save provision dialogs
     dialog_array.each do |dialog|
       # Set the filename and replace characters that are not allowed in filenames
-      # Illegal characters: '/', '|', ' '
-      # Replaced with: '_'
-      fname = "#{dialog[:name]}.yaml".gsub(%r{[|/ ]}, "_")
-
+      fname = MiqIllegalChars.replace("#{dialog[:name]}.yaml", options)
       File.write("#{filedir}/#{fname}", dialog.to_yaml)
     end
   end
@@ -85,7 +84,8 @@ namespace :rhconsulting do
 
     desc 'Exports all provisioning dialogs to individual YAML files'
     task :export, [:filedir] => [:environment] do |_, arguments|
-      ProvisionDialogImportExport.new.export(arguments[:filedir])
+      options = RhconsultingOptions.parse_options(arguments.extras)
+      ProvisionDialogImportExport.new.export(arguments[:filedir], options)
     end
 
   end

--- a/rhconsulting_provision_dialogs.rake
+++ b/rhconsulting_provision_dialogs.rake
@@ -17,7 +17,9 @@ class ProvisionDialogImportExport
     # Save provision dialogs
     dialog_array.each do |dialog|
       # Set the filename and replace characters that are not allowed in filenames
-      fname = "#{dialog[:name]}.yaml".gsub(%r{[|/]}, "_")
+      # Illegal characters: '/', '|', ' '
+      # Replaced with: '_'
+      fname = "#{dialog[:name]}.yaml".gsub(%r{[|/ ]}, "_")
 
       File.write("#{filedir}/#{fname}", dialog.to_yaml)
     end

--- a/rhconsulting_reports.rake
+++ b/rhconsulting_reports.rake
@@ -22,8 +22,12 @@ class MiqReportImportExport
     raise "Must supply export dir" if export_dir.blank?
     custom_reports = MiqReport.where(:rpt_type => "Custom")
     custom_reports.each { |report|
-      File.write("#{export_dir}/#{report.id}_#{report.name.gsub('/', '_')}.yml", 
-                 report.export_to_array.to_yaml)
+      # Replace invalid filename characters
+      # Illegal characters: '/', '|', ' '
+      # Replaced with: '_'
+      name = report.name.gsub(%r{[/| ]}, '_')
+      fname = "#{report.id}_#{name}.yaml"
+      File.write("#{export_dir}/#{fname}", report.export_to_array.to_yaml)
     }
   end
 end

--- a/rhconsulting_reports.rake
+++ b/rhconsulting_reports.rake
@@ -1,4 +1,6 @@
 # Author: George Goh <george.goh@redhat.com>
+require_relative 'rhconsulting_illegal_chars'
+require_relative 'rhconsulting_options'
 
 class MiqReportImportExport
   class ParsedNonDialogYamlError < StandardError; end
@@ -18,14 +20,12 @@ class MiqReportImportExport
     end
   end
 
-  def export(export_dir)
+  def export(export_dir, options = {})
     raise "Must supply export dir" if export_dir.blank?
     custom_reports = MiqReport.where(:rpt_type => "Custom")
     custom_reports.each { |report|
       # Replace invalid filename characters
-      # Illegal characters: '/', '|', ' '
-      # Replaced with: '_'
-      name = report.name.gsub(%r{[/| ]}, '_')
+      name = MiqIllegalChars.replace(report.name, options)
       fname = "#{report.id}_#{name}.yaml"
       File.write("#{export_dir}/#{fname}", report.export_to_array.to_yaml)
     }
@@ -48,7 +48,8 @@ namespace :rhconsulting do
 
     desc 'Exports all custom reports to individual YAML files'
     task :export, [:filedir] => [:environment] do |_, arguments|
-      MiqReportImportExport.new.export(arguments[:filedir])
+      options = RhconsultingOptions.parse_options(arguments.extras)
+      MiqReportImportExport.new.export(arguments[:filedir], options)
     end
 
   end

--- a/rhconsulting_roles.rake
+++ b/rhconsulting_roles.rake
@@ -32,8 +32,10 @@ class RoleImportExport
     elsif file_type == 'directory'
       roles_array.each do |role_hash|
         role_name = role_hash["name"]
-        role_name = role_name.gsub('/', '_')
-        role_name = role_name.gsub('|', '_')
+        # Replace invalid filename characters
+        # Illegal characters: '/', '|', ' '
+        # Replaced with: '_'
+        role_name = role_name.gsub(%r{[/| ]}, '_')
         fname = "#{filename}/#{role_name}.yaml"
         File.write(fname, [role_hash].to_yaml)
       end

--- a/rhconsulting_roles.rake
+++ b/rhconsulting_roles.rake
@@ -1,3 +1,6 @@
+require_relative 'rhconsulting_illegal_chars'
+require_relative 'rhconsulting_options'
+
 class RoleImportExport
   class ParsedNonDialogYamlError < StandardError; end
 
@@ -16,7 +19,7 @@ class RoleImportExport
     end
   end
 
-  def export(filename)
+  def export(filename, options = {})
     raise "Must supply filename or directory" if filename.blank?
     begin
       file_type = File.ftype(filename)
@@ -33,9 +36,7 @@ class RoleImportExport
       roles_array.each do |role_hash|
         role_name = role_hash["name"]
         # Replace invalid filename characters
-        # Illegal characters: '/', '|', ' '
-        # Replaced with: '_'
-        role_name = role_name.gsub(%r{[/| ]}, '_')
+        role_name = MiqIllegalChars.replace(role_name, options)
         fname = "#{filename}/#{role_name}.yaml"
         File.write(fname, [role_hash].to_yaml)
       end
@@ -89,7 +90,8 @@ namespace :rhconsulting do
 
     desc 'Exports all roles to a YAML file or directory'
     task :export, [:filename] => [:environment] do |_, arguments|
-      RoleImportExport.new.export(arguments[:filename])
+      options = RhconsultingOptions.parse_options(arguments.extras)
+      RoleImportExport.new.export(arguments[:filename], options)
     end
 
   end

--- a/rhconsulting_service_catalogs.rake
+++ b/rhconsulting_service_catalogs.rake
@@ -1,3 +1,6 @@
+require_relative 'rhconsulting_illegal_chars'
+require_relative 'rhconsulting_options'
+
 class ServiceCatalogsImportExport
 
   def import(filedir)
@@ -25,7 +28,7 @@ class ServiceCatalogsImportExport
     end
   end
 
-  def export(filedir)
+  def export(filedir, options = {})
     raise "Must supply filedir" if filedir.blank?
     catalogs_hash = export_service_template_catalogs(ServiceTemplateCatalog.in_region(MiqRegion.my_region_number).order(:id).all)
     templates_hash = export_service_templates(ServiceTemplate.in_region(MiqRegion.my_region_number).order(:id).all)
@@ -42,9 +45,7 @@ class ServiceCatalogsImportExport
       data = []
       data << output
       # Replace invalid filename characters
-      # Illegal characters: '/', '|', ' '
-      # Replaced with: '_'
-      fname = output["#{catalog_name}"]['name'].gsub(%r{[/| ]}, '_')
+      fname = MiqIllegalChars.replace(output["#{catalog_name}"]['name'], options)
       File.write("#{filedir}/#{fname}.yml", data.to_yaml)
     }
   end
@@ -285,7 +286,8 @@ namespace :rhconsulting do
 
     desc 'Exports all dialogs to a YAML file'
     task :export, [:filedir] => [:environment] do |_, arguments|
-      ServiceCatalogsImportExport.new.export(arguments[:filedir])
+      options = RhconsultingOptions.parse_options(arguments.extras)
+      ServiceCatalogsImportExport.new.export(arguments[:filedir], options)
     end
 
   end

--- a/rhconsulting_service_catalogs.rake
+++ b/rhconsulting_service_catalogs.rake
@@ -41,7 +41,11 @@ class ServiceCatalogsImportExport
       }
       data = []
       data << output
-      File.write("#{filedir}/#{output["#{catalog_name}"]['name']}.yml", data.to_yaml)
+      # Replace invalid filename characters
+      # Illegal characters: '/', '|', ' '
+      # Replaced with: '_'
+      fname = output["#{catalog_name}"]['name'].gsub(%r{[/| ]}, '_')
+      File.write("#{filedir}/#{fname}.yml", data.to_yaml)
     }
   end
 

--- a/rhconsulting_service_dialogs.rake
+++ b/rhconsulting_service_dialogs.rake
@@ -7,7 +7,11 @@ class ServiceDialogImportExport
     dialogs_hash.each { |x|
       data = []
       data << x
-      File.write("#{filedir}/#{x['label']}.yml", data.to_yaml)
+      # Replace invalid filename characters
+      # Illegal characters: '/', '|', ' '
+      # Replaced with: '_'
+      fname = x['label'].gsub(%r{[/| ]}, '_')
+      File.write("#{filedir}/#{fname}.yml", data.to_yaml)
     }
   end
 

--- a/rhconsulting_tags.rake
+++ b/rhconsulting_tags.rake
@@ -1,3 +1,6 @@
+require_relative 'rhconsulting_illegal_chars'
+require_relative 'rhconsulting_options'
+
 class TagImportExport
   class ParsedNonClassificationYamlError < StandardError; end
 
@@ -16,7 +19,7 @@ class TagImportExport
     end
   end
 
-  def export(filename)
+  def export(filename, options = {})
     raise "Must supply filename or directory" if filename.blank?
     begin
       file_type = File.ftype(filename)
@@ -37,9 +40,7 @@ class TagImportExport
         description = "#{category.description}"
 
         # Replace invalid filename characters
-        # Illegal characters: '/', '|', ' '
-        # Replaced with: '_'
-        description = description.gsub(%r{[/| ]}, '_')
+        description = MiqIllegalChars.replace(description, options)
         fname = "#{filename}/#{description}.yaml"
 
         File.write(fname, category.export_to_yaml)
@@ -106,7 +107,8 @@ namespace :rhconsulting do
 
     desc 'Exports all tags to a YAML file'
     task :export, [:filename] => [:environment] do |_, arguments|
-      TagImportExport.new.export(arguments[:filename])
+      options = RhconsultingOptions.parse_options(arguments.extras)
+      TagImportExport.new.export(arguments[:filename], options)
     end
 
   end

--- a/rhconsulting_tags.rake
+++ b/rhconsulting_tags.rake
@@ -37,8 +37,9 @@ class TagImportExport
         description = "#{category.description}"
 
         # Replace invalid filename characters
-        description = description.gsub('/', '_')
-        description = description.gsub('|', '_')
+        # Illegal characters: '/', '|', ' '
+        # Replaced with: '_'
+        description = description.gsub(%r{[/| ]}, '_')
         fname = "#{filename}/#{description}.yaml"
 
         File.write(fname, category.export_to_yaml)

--- a/rhconsulting_widgets.rake
+++ b/rhconsulting_widgets.rake
@@ -24,7 +24,7 @@ private
     custom_widgets.each { |widget|
 
       # Set the filename and replace spaces and characters that are not allowed in filenames
-      fname = "#{widget.id}_#{widget.name}.yaml".gsub(%r{[|/]}, "_")
+      fname = "#{widget.id}_#{widget.name}.yaml".gsub(%r{[|/ ]}, "_")
 
       File.write("#{export_dir}/#{fname}", widget.export_to_array.to_yaml)
     }

--- a/rhconsulting_widgets.rake
+++ b/rhconsulting_widgets.rake
@@ -1,13 +1,15 @@
 # Author: Brant Evans <bevans@redhat.com>
+require_relative 'rhconsulting_illegal_chars'
+require_relative 'rhconsulting_options'
 
 class MiqWidgetsImportExport
   class ParsedNonDialogYamlError < StandardError; end
 
-  def export(export_dir)
+  def export(export_dir, options = {})
     raise "Must supply export dir" if export_dir.blank?
 
     # Export the Policies
-    export_widgets(export_dir)
+    export_widgets(export_dir, options)
   end
 
   def import(import_dir)
@@ -19,12 +21,12 @@ class MiqWidgetsImportExport
 
 private
 
-  def export_widgets(export_dir)
+  def export_widgets(export_dir, options)
     custom_widgets = MiqWidget.where(:read_only => "false")
     custom_widgets.each { |widget|
 
       # Set the filename and replace spaces and characters that are not allowed in filenames
-      fname = "#{widget.id}_#{widget.name}.yaml".gsub(%r{[|/ ]}, "_")
+      fname = MiqIllegalChars.replace("#{widget.id}_#{widget.name}.yaml", options)
 
       File.write("#{export_dir}/#{fname}", widget.export_to_array.to_yaml)
     }
@@ -54,7 +56,8 @@ namespace :rhconsulting do
 
     desc 'Exports all widgets to individual YAML files'
     task :export, [:filedir] => [:environment] do |_, arguments|
-      MiqWidgetsImportExport.new.export(arguments[:filedir])
+      options = RhconsultingOptions.parse_options(arguments.extras)
+      MiqWidgetsImportExport.new.export(arguments[:filedir], options)
     end
 
     desc 'Imports all policies from individual YAML files'


### PR DESCRIPTION
This pull request contains several new features:

- Support for individual files - Some of the import functions in the shell script only supported importing whole directories, even though the Ruby code supported importing individual files. I've modified the shell script to support both scenarios

- Support for names with spaces - Lots of changes here. The shell scripts were not very forgiving for importing/exporting file paths that contained spaces. I added quotes in the the shell scripts to support this.  I also changed the export filename regex to replace ' ' with '_' so that by default the filenames do not have spaces in them.

- Support for relative paths and symlinks - Previously, running miqimport/miqexport on a relative path would fail with some odd errors. All that was needed here was to add a "readlink" on the path argument to resolve the absolute path from the relative.

Please let me know if you have suggestions or find any bugs.

Thanks,
Nick
