### PR TITLE
Fixed exception why trying to overwrite a domain that doesn't exist.

### DIFF
--- a/rhconsulting_miq_ae_datastore.rake
+++ b/rhconsulting_miq_ae_datastore.rake
@@ -12,7 +12,7 @@ class MiqAeDatastoreImportExport
     # This is exactly what happens in newer versions where overwrite is fixed.
     if options['overwrite'] && Vmdb::Appliance.VERSION < "5.6"
       domain_obj = MiqAeDomain.find_by_name(domain_name)
-      domain_obj.destroy
+      domain_obj.destroy if domain_obj
     end
     importer.import
   end


### PR DESCRIPTION
In my latest code i had a bug where an exception was throw during a domain over-write operation if the domain didn't exist already. 