### PR TITLE
Make domain export filter more specific

### DIFF
--- a/bin/miqexport
+++ b/bin/miqexport
@@ -86,7 +86,7 @@ op_all () {
   pushd "automate"
   DOMAIN_ROOT_DIR=`pwd`
   pushd /var/www/miq/vmdb
-  DOMAINS=$(bin/rake evm:automate:list_class |tail -n+3 |cut -d/ -f2 -|sed 's|/||'|egrep -v 'ManageIQ|RedHat'|sort|uniq)
+  DOMAINS=$(bin/rake evm:automate:list_class |tail -n+3 |cut -d/ -f2 -|sed 's|/||'|egrep -v '^(ManageIQ|RedHat)$'|sort|uniq)
 
   while read -r DOMAIN; do
     DOMAINDIR=$(readlink -v -f "$DOMAIN_ROOT_DIR")


### PR DESCRIPTION
Hi,
This small commit is to make the filter for exporting Automate Domains more specific.
This is needed because otherwise any automate domain that contains `ManageIQ` and `RedHat` will *not* be exported.  On the other hand, if this patch is applied, only domains that their names match exactly `ManageIQ` and `RedHat` will be filtered out.
