### PR TITLE
Fixed a bug in miqimport all was not importing domains properly

### DIFF
--- a/bin/miqimport
+++ b/bin/miqimport
@@ -213,7 +213,7 @@ op_all () {
       for domdir in $dir/*
       do
 	[ ! -d "$domdir" ] && continue || :
-	op_domain "$(basename $domdir)" "$domdir"
+	op_domain "$(basename $domdir)" "$dir"
       done
       continue
     fi


### PR DESCRIPTION
The `bin/miqimport` functionality contained a small bug whereby automate domains where not being imported properly.

This PR fixes that.
