### PR TITLE
Bump version number to match .spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.10
+VERSION := 0.11
 RELEASE := 1
 
 .PHONY: clean rpm install clean-install


### PR DESCRIPTION
make rpm fails because Makefile and .spec file versions were mismatched. Bumped Makefile to match .spec.