### PR TITLE
move where blueprint_id is deleted

### DIFF
--- a/rhconsulting_service_dialogs.rake
+++ b/rhconsulting_service_dialogs.rake
@@ -36,7 +36,6 @@ class ServiceDialogImportExport
 
   def import_dialogs_from_file(filename)
     dialogs = YAML.load_file(filename)
-    dialogs.first.delete('blueprint_id') # This field is not found in 4.6 and breaks the import of exports from previous versions.
     import_dialogs(dialogs)
   end
 
@@ -44,6 +43,7 @@ class ServiceDialogImportExport
     begin
       dialogs.each do |d|
         puts "Dialog: [#{d['label']}]"
+        d.delete('blueprint_id') # This field is not found in 4.6 and breaks the import of exports from previous versions.
         dialog = Dialog.find_by_label(d["label"])
         if dialog
           dialog.update_attributes!("dialog_tabs" => import_dialog_tabs(d))


### PR DESCRIPTION
Move where deleting `blueprint_id` occurs to handle instances of importing a file with more than one service dialog.