### PR TITLE
Adds support for Ansible Inside Config Script sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ rm-installed-files:
 	rm -f /usr/bin/export-miqdomain
 	rm -f /usr/bin/import-miqdomain
 	rm -f /var/www/miq/vmdb/lib/tasks/rhconsulting_scanitems.rake
+	rm -f /var/www/miq/vmdb/lib/tasks/rhconsulting_scriptsrc.rake
 
 install:
 	install -Dm644 rhconsulting_buttons.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_buttons.rake
@@ -42,6 +43,7 @@ install:
 	install -Dm644 rhconsulting_illegal_chars.rb /var/www/miq/vmdb/lib/tasks/rhconsulting_illegal_chars.rb
 	install -Dm644 rhconsulting_options.rb /var/www/miq/vmdb/lib/tasks/rhconsulting_options.rb
 	install -Dm644 rhconsulting_scanitems.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_scanitems.rake
+	install -Dm644 rhconsulting_scriptsrc.rake /var/www/miq/vmdb/lib/tasks/rhconsulting_scriptsrc.rake
 	install -Dm755 bin/miqexport /usr/bin/miqexport
 	install -Dm755 bin/miqimport /usr/bin/miqimport
 	install -Dm755 bin/export-miqdomain /usr/bin/export-miqdomain

--- a/README.adoc
+++ b/README.adoc
@@ -74,6 +74,7 @@ Available Object Types:
   alertsets                        Export alert sets.
   policies                         Export policies.
   scanitems                        Export scan items.
+  scriptsrc                        Export config script sources.
   domain <name>                    Export the specified domain from the
                                    Automate Engine Datastore. <name> MUST
                                    be specified.
@@ -123,6 +124,7 @@ Available Object Types:
   alertsets                        Import alert sets.
   policies                         Import policies.
   scanitems                        Import scan items.
+  scriptsrc                        Import config script sources
   domain <name>                    Import the specified domain from the
                                    <importsource> directory. <name> MUST
                                    be specified.
@@ -156,7 +158,7 @@ BUILDDIR=/tmp/CFME-build
 DOMAIN_EXPORT=YourDomainHere
 
 rm -fR ${BUILDDIR}
-mkdir -p ${BUILDDIR}/{service_catalogs,dialogs,roles,tags,buttons,customization_templates,policies,alerts,alertsets,widgets,miq_ae_datastore,scanitems}
+mkdir -p ${BUILDDIR}/{service_catalogs,dialogs,roles,tags,buttons,customization_templates,policies,alerts,alertsets,widgets,miq_ae_datastore,scanitems,scriptsrc}
 
 cd /var/www/miq/vmdb
 bin/rake rhconsulting:provision_dialogs:export[${BUILDDIR}/provision_dialogs]
@@ -172,6 +174,7 @@ bin/rake rhconsulting:miq_alerts:export[${BUILDDIR}/alerts]
 bin/rake rhconsulting:miq_alertsets:export[${BUILDDIR}/alertsets]
 bin/rake rhconsulting:miq_widgets:export[${BUILDDIR}/widgets]
 bin/rake rhconsulting:miq_scanprofiles:export[${BUILDDIR}/scanitems]
+bin/rake rhconsulting:miq_scriptsrc:export[${BUILDDIR}/scriptsrc]
 bin/rake "rhconsulting:miq_ae_datastore:export[${DOMAIN_EXPORT}, ${BUILDDIR}/miq_ae_datastore]"
 
 ----
@@ -197,6 +200,7 @@ BUILDDIR=/tmp/CFME-build
 DOMAIN_IMPORT=YourDomainHere
 
 cd /var/www/miq/vmdb
+bin/rake rhconsulting:miq_scriptsrc:import[${BUILDDIR}/scriptsrc]
 bin/rake rhconsulting:provision_dialogs:import[${BUILDDIR}/provision_dialogs]
 bin/rake rhconsulting:service_dialogs:import[${BUILDDIR}/service_dialogs]
 bin/rake rhconsulting:roles:import[${BUILDDIR}/roles/roles.yml]

--- a/bin/export-miqdomain
+++ b/bin/export-miqdomain
@@ -36,7 +36,7 @@ absolute_path()
 
 export ()
 {
-  mkdir -p "${BUILDDIR}"/{provision_dialogs,service_catalogs,service_dialogs,roles,tags,buttons,customization_templates,reports,widgets,policies,scanitems,alerts,alertsets,miq_ae_datastore}
+  mkdir -p "${BUILDDIR}"/{provision_dialogs,service_catalogs,service_dialogs,roles,tags,buttons,customization_templates,reports,widgets,policies,scanitems,alerts,alertsets,miq_ae_datastore,scriptsrc}
 
   cd /var/www/miq/vmdb
   bin/rake rhconsulting:provision_dialogs:export["${BUILDDIR}/provision_dialogs"]
@@ -50,6 +50,7 @@ export ()
   bin/rake rhconsulting:customization_templates:export["${BUILDDIR}/customization_templates/customization_templates.yml"]
   bin/rake rhconsulting:miq_policies:export["${BUILDDIR}/policies"]
   bin/rake rhconsulting:miq_scanprofiles:export["${BUILDDIR}/scanitems"]
+  bin/rake rhconsulting:miq_scriptsrc:export["${BUILDDIR}/scriptsrc"]
   bin/rake rhconsulting:miq_alerts:export["${BUILDDIR}/alerts"]
   bin/rake rhconsulting:miq_alertsets:export["${BUILDDIR}/alertsets"]
   bin/rake "rhconsulting:miq_ae_datastore:export[${DOMAIN},${BUILDDIR}/miq_ae_datastore]"

--- a/bin/import-miqdomain
+++ b/bin/import-miqdomain
@@ -54,6 +54,14 @@ import()
 {
   cd /var/www/miq/vmdb
 
+  src="${DIR}/scriptsrc"
+  if [ -d "${src}" ]; then
+    echo "Importing ${src} directory..."
+    bin/rake rhconsulting:miq_scriptsrc:import[${src}]
+  else
+    echo "Skipping ${src} directory as it does not exist."
+  fi
+
   src="${DIR}/provision_dialogs"
   if [ -d "${src}" ]; then
     echo "Importing ${src} directory..."

--- a/bin/miqexport
+++ b/bin/miqexport
@@ -87,6 +87,9 @@ op_all () {
 
   mkdir_if_needed "scanitems"
   op_scanitems scanitems &
+  
+  mkdir_if_needed "scriptsrc"
+  op_scriptsrc scriptsrc &
 
   mkdir_if_needed "automate"
   pushd "automate"
@@ -180,6 +183,15 @@ op_scanitems () {
   popd
 }
 
+op_scriptsrc () {
+  assert_num_args $# 1
+  EXPORT_DIR=$(readlink -v -f "$1")
+  assert_export_dir_exists "$EXPORT_DIR"
+
+  pushd /var/www/miq/vmdb
+  bin/rake "rhconsulting:miq_scriptsrc:export[${EXPORT_DIR},keep_spaces=${KEEP_SPACES}]"
+  popd
+}
 
 op_provision_dialogs () {
   assert_num_args $# 1
@@ -356,6 +368,7 @@ Available Object Types:
   alertsets                        Export alert sets.
   policies                         Export policies.
   scanitems                        Export scanitems.
+  scriptsrc                        Export config script sources.
   domain <name>                    Export the specified domain from the
                                    Automate Engine Datastore. <name> MUST
                                    be specified.

--- a/bin/miqimport
+++ b/bin/miqimport
@@ -129,6 +129,17 @@ op_scanitems () {
   popd
 }
 
+op_scriptsrc () {
+  assert_num_args $# 1
+  IMPORT_DIR=$(readlink -v -f "$1")
+  assert_import_dir_exists "$IMPORT_DIR"
+
+  pushd /var/www/miq/vmdb
+  bin/rake "rhconsulting:miq_scriptsrc:import[${IMPORT_DIR}]"
+  popd
+}
+
+
 op_provision_dialogs () {
   assert_num_args $# 1
   IMPORT_FILE_OR_DIR=$(readlink -v -f "$1")
@@ -371,6 +382,7 @@ Available Object Types:
   widgets                          Import custom widgets.
   policies                         Import policies.
   scanitems                        Import scanitems.
+  scriptsrc                        Import config script sources.
   domain <name>                    Import the specified domain from the
                                    <importsource> directory. <name> MUST
                                    be specified.

--- a/cfme-rhconsulting-scripts.spec
+++ b/cfme-rhconsulting-scripts.spec
@@ -46,6 +46,7 @@ install --backup --mode=0755 -t "%{buildroot}/usr/bin" bin/import-miqdomain
 /var/www/miq/vmdb/lib/tasks/rhconsulting_illegal_chars.rb
 /var/www/miq/vmdb/lib/tasks/rhconsulting_options.rb
 /var/www/miq/vmdb/lib/tasks/rhconsulting_scanitems.rake
+/var/www/miq/vmdb/lib/tasks/rhconsulting_scriptsrc.rake
 /usr/bin/miqexport
 /usr/bin/miqimport
 /usr/bin/export-miqdomain

--- a/rhconsulting_scriptsrc.rake
+++ b/rhconsulting_scriptsrc.rake
@@ -1,0 +1,131 @@
+# Author: A Liu Ly <alejandrol@t-systems.com>
+require_relative 'rhconsulting_illegal_chars'
+require_relative 'rhconsulting_options'
+
+class MiqScrSrcImportExport
+  class ParsedNonDialogYamlError < StandardError; end
+
+  def export(export_dir, options = {})
+    raise "Must supply export dir" if export_dir.blank?
+    export_repo_items(export_dir, options)
+  end
+
+  def import(import_dir)
+    raise "Must supply import dir" if import_dir.blank?
+    # Import the git repos
+    import_repo_items(import_dir)
+  end
+
+private
+  def extract_scrsrc(src)
+    gitrepo = {
+      "name" => src.name,
+      "type" => src.type,
+      "description" => src.description,
+      "scm_type" => src.scm_type,
+      "scm_url" => src.scm_url,
+      "scm_branch" => src.scm_branch,
+      "scm_clean" => src.scm_clean,
+      "scm_delete_on_update" => src.scm_delete_on_update,
+      "scm_update_on_launch" => src.scm_update_on_launch,
+    }
+    if ! src.authentication_id.nil?
+      gitrepo["authentication"] = ::Authentication.find_by(:id => src.authentication_id).name
+    end
+    return gitrepo
+  end
+
+  def lookup_auth(gitrepo)
+    if gitrepo.has_key?("authentication")
+      gitrepo["authentication_id"] = ::Authentication.find_by(:name => gitrepo["authentication"]).id
+      gitrepo.delete("authentication")
+    end
+  end
+
+  def export_repo_items(export_dir, options)
+    ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource.all.each do |src|
+      # Replace invalid filename characters
+      pname = MiqIllegalChars.replace(src.name, options)
+      fname = "#{pname}.yaml"
+      puts("Export: #{src.name} to #{fname}")
+      repo = extract_scrsrc(src)
+      File.write("#{export_dir}/#{fname}", repo.to_yaml)
+    end
+  end
+
+  def import_repo_items(import_dir)
+    ea = Provider.find_by(:type => "ManageIQ::Providers::EmbeddedAnsible::Provider")
+    return if ea.nil?
+
+    Dir.glob("#{import_dir}/*.yaml") do |filename|
+      puts("Importing Repo File: #{File.basename(filename, '.yaml')} ....")
+      yaml = YAML.load_file(filename)
+      csrc = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource.find_by(:name => yaml["name"])
+      if csrc.nil?
+	# Create repo
+	puts("Creating repo #{yaml["name"]}")
+	lookup_auth(yaml)
+	ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource.create_in_provider_queue(ea.id, yaml.deep_symbolize_keys)
+
+	# Check that the script source was created
+	retries = 10
+	begin
+	  retries -= 1
+	  csrc = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource.find_by(:name => yaml["name"])
+	  if ! csrc.nil?
+	    puts "Created #{yaml['name']} as #{csrc.id}"
+	    break
+	  end      
+	  sleep 6
+	end while retries > 0
+
+      else
+	tm = extract_scrsrc(csrc)
+	if tm.to_yaml != yaml.to_yaml
+	  puts("Modify #{yaml["name"]}")
+	  yy = yaml.dup
+	  lookup_auth(yy)
+	  #puts(yy.to_yaml)
+	  csrc.update_in_provider_queue(yy.deep_symbolize_keys)
+	  # Check that the script source was updated
+	  retries = 10
+	  begin
+	    retries -= 1
+	    csrc = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource.find_by(:name => yaml["name"])
+	    if ! csrc.nil?
+	      tm = extract_scrsrc(csrc)
+	      if tm.to_yaml == yaml.to_yaml
+		puts "Updated #{yaml['name']} as #{csrc.id}"
+		break
+	      end
+	    end      
+	    sleep 6
+	  end while retries > 0
+	end
+      end
+    end
+    ManageIQ::Providers::EmbeddedAnsible::AutomationManager.refresh_ems([ea.id])
+  end
+
+end
+
+namespace :rhconsulting do
+  namespace :miq_scriptsrc do
+
+    desc 'Usage information'
+    task :usage => [:environment] do
+      puts 'Import - Usage: rake \'rhconsulting:miq_scriptsrc:import[/path/to/dir/with/script/sources]\''
+      puts 'Export - Usage: rake \'rhconsulting:miq_scriptsrc:export[/path/to/dir/with/script/sources]\''
+    end
+
+    desc 'Imports all script sources from individual YAML files'
+    task :import, [:filedir] => [:environment] do |_, arguments|
+      MiqScrSrcImportExport.new.import(arguments[:filedir])
+    end
+    desc 'Exports all script sources to individual YAML files'
+    task :export, [:filedir] => [:environment] do |_, arguments|
+      MiqScrSrcImportExport.new.export(arguments[:filedir])
+    end
+
+  end
+end


### PR DESCRIPTION
Hi,

This pull-request add support for importing/exporting AnsibleInside's Config Script sources (found in
"automate -> Ansible -> Repositories")

If a repository requires credentials, these need to be already available (i.e. defined from the GUI) and listed by name in the YAML file.

This changes the service catalogs, so that Ansible Inside playbooks are exported by name (instead of by id).  This makes sure if there is an order discrepancy on how the repositories are imported, they would
still refer to the same playbooks.
