### PR TITLE
Add support for button enablement expressions

### DIFF
--- a/rhconsulting_buttons.rake
+++ b/rhconsulting_buttons.rake
@@ -149,6 +149,7 @@ class ButtonsImportExport
           custom_button['wait_for_complete'] = cb['wait_for_complete']
           custom_button['visibility'] = cb['visibility']
           custom_button['visibility_expression'] = cb['visibility_expression']
+          custom_button['enablement_expression'] = cb['enablement_expression']
           custom_button['applies_to_id'] = cb['applies_to_id']
           #custom_button['resource_actions'] = cb['resource_actions']
           custom_button.resource_action = cb['resource_actions']
@@ -207,7 +208,7 @@ class ButtonsImportExport
       custom_buttons.collect do |custom_button|
         button = custom_button.attributes.slice(
             'description', 'applies_to_class', 'applies_to_exp', 'options', 'userid',
-            'wait_for_complete', 'name', 'visibility', 'visibility_expression', 'applies_to_id')
+            'wait_for_complete', 'name', 'visibility', 'visibility_expression', 'enablement_expression', 'applies_to_id')
         button['resource_actions'] = export_resource_actions(custom_button.resource_action)
         buttons << button
       end


### PR DESCRIPTION
in 5.9 custom buttons gained the ability to control visibility and
enablement (aka greyed out) based on expression methods, which needs
to be accounted for in the import/export.
visilility was fixed in #123 by lynndixon. This is basically the same
fix for enablement