### PR TITLE
Add missing attribute 'disabled_text'

### DIFF
--- a/rhconsulting_buttons.rake
+++ b/rhconsulting_buttons.rake
@@ -151,6 +151,7 @@ class ButtonsImportExport
           custom_button['visibility_expression'] = cb['visibility_expression']
           custom_button['enablement_expression'] = cb['enablement_expression']
           custom_button['applies_to_id'] = cb['applies_to_id']
+          custom_button['disabled_text'] = cb['disabled_text']
           #custom_button['resource_actions'] = cb['resource_actions']
           custom_button.resource_action = cb['resource_actions']
           custom_button.update_attributes!(cb) unless !custom_button.nil?
@@ -208,7 +209,8 @@ class ButtonsImportExport
       custom_buttons.collect do |custom_button|
         button = custom_button.attributes.slice(
             'description', 'applies_to_class', 'applies_to_exp', 'options', 'userid',
-            'wait_for_complete', 'name', 'visibility', 'visibility_expression', 'enablement_expression', 'applies_to_id')
+            'wait_for_complete', 'name', 'visibility', 'visibility_expression', 
+            'enablement_expression', 'applies_to_id', 'disabled_text')
         button['resource_actions'] = export_resource_actions(custom_button.resource_action)
         buttons << button
       end


### PR DESCRIPTION
Manageiq Gaprindashvili introduced a feature to conditionally disable custom buttons. This commit adds the 'disabled_text' attribute to the export, which is the text displayed to the user, when hovering over a disabled button