### PR TITLE
Add missing file to %files

### DIFF
--- a/cfme-rhconsulting-scripts.spec
+++ b/cfme-rhconsulting-scripts.spec
@@ -45,6 +45,7 @@ install --backup --mode=0755 -t "%{buildroot}/usr/bin" bin/import-miqdomain
 /var/www/miq/vmdb/lib/tasks/rhconsulting_alerts.rake
 /var/www/miq/vmdb/lib/tasks/rhconsulting_illegal_chars.rb
 /var/www/miq/vmdb/lib/tasks/rhconsulting_options.rb
+/var/www/miq/vmdb/lib/tasks/rhconsulting_model_attributes.rb
 /var/www/miq/vmdb/lib/tasks/rhconsulting_scanitems.rake
 /var/www/miq/vmdb/lib/tasks/rhconsulting_scriptsrc.rake
 /var/www/miq/vmdb/lib/tasks/rhconsulting_schedules.rake


### PR DESCRIPTION
Our jenkins build of the RPM failed due to a missing file in %files.

I ignored the bogus dates in %changelog