### PR TITLE
Fix for broken 'resource_actions' on button import

### DIFF
--- a/rhconsulting_buttons.rake
+++ b/rhconsulting_buttons.rake
@@ -80,22 +80,12 @@ class ButtonsImportExport
     #   end
     #   count += 1
     #end
-    resource_action = ResourceAction.new
-    all_ra = ResourceAction.in_region(MiqRegion.my_region_number)
-    all_ra.each do |find_action|
-      #  puts "checking ra: #{find_action['id']} if it has resource_id of #{find_action['resource_id']}"
-      if find_action['resource_id'] == custom_button.id
-        #    puts "FOUND: #{find_action.inspect}"
-        resource_action = find_action
-        resource_action.reload
-      end
-    end
+    resource_action = ResourceAction.in_region(MiqRegion.my_region_number).find_or_create_by(
+      resource_id: custom_button.id, resource_type: 'CustomButton')
 
     #puts "ResourceActions PRE: #{resource_action.inspect}"
     ra = {}
     ra['action'] = resource_actions['action']
-    ra['resource_id'] = custom_button.id
-    ra['resource_type'] = "CustomButton"
     ra['ae_namespace'] = resource_actions['ae_namespace']
     ra['ae_class'] = resource_actions['ae_class']
     ra['ae_instance'] = resource_actions['ae_instance']


### PR DESCRIPTION
This fixes invalidly updating 'resource_actions' on button import

The code before the fix searches all ResourceActions only by a given resource_id which may result in an invalid selection if the resource_type is not 'CustomButton'.

The updated code also makes sure to search for the resource_type: "CustomButton".

This fixes Issue #114 (at least in our environment).